### PR TITLE
Remove references to significant digits

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Goals and needs
 
-In the real world, it is rare to have a number by itself. Numbers are more often measuring _an amount of something_, from the number of apples in a bowl to the amount of Euros in your bank account, and from the number of milliliters in a cup of water to the number of kWh consumed by an electric car per mile. When measuring a physical quantity, numbers also have a _precision_, or a number of significant digits.
+In the real world, it is rare to have a number by itself. Numbers are more often measuring _an amount of something_, from the number of apples in a bowl to the amount of Euros in your bank account, and from the number of milliliters in a cup of water to the number of kWh consumed by an electric car per mile. When measuring a physical quantity, numbers also have a _precision_.
 
 Intl formatters have long been able to format amounts of things, but the quantity associated with the number is not carried along with the number into Intl APIs, which causes real-world bugs.
 
@@ -34,20 +34,18 @@ Amount will have the following properties:
 Note: ⚠️  All property/method names up for bikeshedding.
 
 * `unit` (String or undefined): The unit of measurement with which number should be understood (with *undefined* indicating "none supplied")
-* `significantDigits` (Number): how many significant digits does this value contain? (Should be a positive integer)
 * `fractionalDigits` (Number): how many digits are required to fully represent the part of the fractional part of the underlying mathematical value. (Should be a non-negative integer.)
 
 #### Precision
 
-A big question is how we should handle precision. When constructing an Amount, both the significant digits and fractional digits are recorded.
+A big question is how we should handle precision. When constructing an Amount, both fractional digits are recorded.
 
 ### Constructor
 
 * `new Amount(value[, options])`. Constructs an Amount with the mathematical value of `value`, and optional `options`, of which the following are supported (all being optional):
   * `unit` (String): a marker for the measurement
   * `fractionDigits`: the number of fractional digits the mathematical value should have (can be less than, equal to, or greater than the actual number of fractional digits that the underlying mathematical value has when rendered as a decimal digit string)
-  * `significantDigits`: the number of significant digits that the mathematical value should have  (can be less than, equal to, or greater than the actual number of significant digits that the underlying mathematical value has when rendered as a decimal digit string)
-  * `roundingMode`: one of the seven supported Intl rounding modes. This option is used when the `fractionDigits` and `significantDigits` options are provided and rounding is necessary to ensure that the value really does have the specified number of fraction/significant digits.
+  * `roundingMode`: one of the seven supported Intl rounding modes. This option is used when the `fractionDigits` options are provided and rounding is necessary to ensure that the value really does have the specified number of fraction digits.
 
 The object prototype would provide the following methods:
 
@@ -67,7 +65,6 @@ First, we'll work with a bare number (no unit):
 ```js
 let a = new Amount("123.456");
 a.fractionDigits; // 3
-a.significantDigits; // 6
 a.with({ fractionDigits: 4 }).toString(); // "123.4560"
 ```
 
@@ -164,14 +161,14 @@ If one downgrades the precision of an Amount, rounding will occur. (Upgrading ju
 
 ```js
 let a = new Amount("123.456");
-a.with({ significantDigits: 5 }).toString(); // "123.46"
+a.with({ fractionDigits: 2 }).toString(); // "123.46"
 ```
 
 By default, we use the round-ties-to-even rounding mode, which is used by IEEE 754 standard, and thus by Number and [Decimal](https://github.com/tc39/proposal-decimal). One can specify a rounding mode:
 
 ```js
 let b = new Amount("123.456");
-a.with({ significantDigits: 5, roundingMode: "truncate" }).toString(); // "123.45"
+a.with({ fractionDigits: 2, roundingMode: "truncate" }).toString(); // "123.45"
 ```
 
 ### Units (including currency)
@@ -241,9 +238,9 @@ The primordial assists with discoverability and adoption. If it is just a protoc
 
 The protocol should likely coexist, as it enables polyfills and cross-membrane code.
 
-### Why represent precision as number of significant digits instead of something else like margin of error?
+### Why represent precision as number of fraction digits instead of something else like margin of error?
 
-Existing ECMA-262 and ECMA-402 APIs deal with precision in terms of significant digits: for example, `Number.prototype.toPrecision` and `minimumSignificantDigits` in `Intl.NumberFormat` and `Intl.PluralRules`. We do not wish to innovate in this area. Further, CLDR does not provide data for formatting of precision any other way, and we are unaware of a feature request for it.
+Existing ECMA-262 and ECMA-402 APIs deal with precision in terms of significant digits: for example, `Number.prototype.toPrecision` and `minimumSignificantDigits` in `Intl.NumberFormat` and `Intl.PluralRules`. With our understanding of fraction digits, there's a standard way to compute significant digits. We do not wish to innovate in this area. Further, CLDR does not provide data for formatting of precision any other way, and we are unaware of a feature request for it.
 
 ## Related/See also
 

--- a/spec.emu
+++ b/spec.emu
@@ -202,23 +202,6 @@ location: https://github.com/tc39/proposal-amount/
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-amount-countmvsignificantdigits" type="abstract operation">
-        <h1>CountMVSignificantDigits (
-          _v_: a mathematical value
-        ): a positive integer
-        </h1>
-        <dl class="header">
-          <dt>description</dt>
-          <dd>It computes the number of significant digits in a given mathematical value, which is assumed to have a finite representation in base 10. Because we deal with mathematical values as input, rather than Strings, the value is tacitly undertood as infinitely precise, which is to say that all digits, even trailing zeroes, are understood here as <q>significant</q>.</dd>
-        </dl>
-        <emu-alg>
-          1. Assert: There exists a non-negative integer _n_ such that _v_ × 10<sup>_n_</sup> is an integer.
-          1. Let _e_ be the smallest non-negative integer such that _v_ × 10<sup>_e_</sup> is an integer.
-          1. Let _scaled_ be _v_ × 10<sup>_e_</sup>.
-          1. Return the count of digits in the decimal representation of _scaled_.
-        </emu-alg>
-      </emu-clause>
-
     <emu-clause id="sec-amount-reverseroundingmode" type="abstract operation">
       <h1>ReverseRoundingMode (
         _mode_: a rounding mode
@@ -265,32 +248,6 @@ location: https://github.com/tc39/proposal-amount/
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-amount-roundtosignificantdigits" type="abstract operation">
-        <h1>RoundToSignificantDigits (
-          _v_: a mathematical value,
-          _n_: a non-negative integer,
-          optional _roundingMode_: a rounding mode
-        ): a mathematical value
-        </h1>
-        <dl class="header">
-          <dt>description</dt>
-          <dd>It computes the closest approximation to a given mathematical value that has at most the given number of significant digits, rounding (if necessary) according to the given rounding mode.</dd>
-        </dl>
-        <emu-alg>
-          1. If _roundingMode_ is *undefined*, set _roundingMode_ to *"halfEven"*.
-          1. If _v_ = 0, return 0.
-          1. If v &lt; 0, then
-            1. Let _reverseRoundingMode_ be ReverseRoundingMode(_roundingMode_).
-            1. Let _d_ be RoundToSignificantDigits(–_v_, _n_, _reverseRoundingMode_).
-            1. Return –_d_.
-          1. Let _e_ be the unique integer such that 10<sup>_e_</sup> ≤ _v_ < 10<sup>_e_+1</sup>.
-          1. Let _pow_ be _e_ - _n_.
-          1. Let _m_ be _v_ × 10<sup>–_pow_</sup>.
-          1. Let _rounded_ be ApplyRoundingModeToPositive(_m_, _roundingMode_).
-          1. Return _rounded_ × 10<sup>_n_ + _e_</sup>.
-        </emu-alg>
-      </emu-clause>
-
       <emu-clause id="sec-amount-rendermvwithfractiondigits" type="abstract operation">
         <h1>RenderAmountValueWithFractionDigits (
           _v_: an Intl mathematical value,
@@ -330,7 +287,7 @@ location: https://github.com/tc39/proposal-amount/
       <emu-clause id="sec-amount-getamountoptions" type="abstract operation">
         <h1>GetAmountOptions (
           _opts_: an Object
-        ): either a normal completion containing a Record with fields [[FractionDigits]] (a non-negative integer or *undefined*), [[RoundingMode]] (a <emu-xref href="#dfn-amount-rounding-mode">rounding mode</emu-xref>), [[SignificantDigits]] (a positive integer or *undefined*), and [[Unit]] (a String or *undefined*) or a throw completion
+        ): either a normal completion containing a Record with fields [[FractionDigits]] (a non-negative integer or *undefined*), [[RoundingMode]] (a <emu-xref href="#dfn-amount-rounding-mode">rounding mode</emu-xref>), and [[Unit]] (a String or *undefined*) or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
@@ -340,16 +297,10 @@ location: https://github.com/tc39/proposal-amount/
           1. Let _opts_ be ? GetOptionsObject(_opts_).
           1. Let _fractionDigits_ be ? GetOption(_opts_, *"fractionDigits"*, ~number~, ~empty~, *undefined*).
           1. Let _roundingMode_ be ? GetOption(_opts_, *"roundingMode"*, ~string~, « *"ceil"*, *"floor"*, *"expand"*, *"trunc"*, *"halfCeil"*, *"halfFloor"*, *"halfExpand"*, *"halfTrunc"*, *"halfEven"* », *"halfEven"*).
-          1. Let _significantDigits_ be ? GetOption(_opts_, *"significantDigits"*, ~number~, ~empty~, *undefined*).
           1. Let _unit_ be ? GetOption(_opts_, *"unit"*, ~string~, ~empty~, *undefined*).
           1. If _fractionDigits_ is not *undefined*, then
-            1. If _significantDigits_ is not *undefined*, throw a *RangeError* exception.
             1. If _fractionDigits_ is not a non-negative integral number, throw a *RangeError* exception.
-          1. Else if _significantDigits_ is not *undefined*, then
-            1. If _significantDigits_ is not an integral number, throw a *RangeError* exception.
-            1. If ℝ(_significantDigits_) < 1, throw a *RangeError* exception.
-          1. If _unit_ is the empty String, throw a *RangeError* exception.
-          1. Return the Record { [[FractionDigits]]: _fractionDigits_, [[RoundingMode]]: _roundingMode_, [[SignificantDigits]]: _significantDigits, [[Units]]: _unit_ }.
+          1. Return the Record { [[FractionDigits]]: _fractionDigits_, [[RoundingMode]]: _roundingMode_, [[Units]]: _unit_ }.
         </emu-alg>
       </emu-clause>
     </emu-clause>
@@ -379,38 +330,20 @@ location: https://github.com/tc39/proposal-amount/
         1. Let _validatedOpts_ be ? GetAmountOptions(_opts_).
         1. Let _fractionDigits_ be _validatedOpts_.[[FractionDigits]].
         1. Let _roundingMode_ be _validatedOpts_.[[RoundingMode]].
-        1. Let _significantDigits_ be _validatedOpts_.[[SignificantDigits]].
         1. Let _unit_ be _validatedOpts_.[[Unit]].
-        1. Let _O_ be OrdinaryObjectCreate(%Amount.prototype%, « [[FractionDigits]], [[SignificantDigits]], [[Unit]], [[Value]] »).
+        1. Let _O_ be OrdinaryObjectCreate(%Amount.prototype%, « [[FractionDigits]], [[Unit]], [[Value]] »).
         1. If _amountValue_ is a mathematical value, then
           1. Let _roundedValue_ be _amountValue_.
-          1. If both _significantDigits_ and _fractionDigits_ are *undefined*, then
-            1. Set _significantDigits_ to _numDigits_.
-            1. Set _fractionDigits_ to CountFractionDigits(_toParse_).
-          1. Else if _significantDigits_ is *undefined*, then
-            1. Set _roundedValue_ be RoundAmountValueToFractionDigits(_amountValue_, _fractionDigits_, _roundingMode_).
-            1. Let _e_ be the smallest non-negative integer such that _roundedValue_ × 10<sup>-_e_</sup> is an integer.
-            1. Let _scaledRoundedValue_ be _roundedValue_ × 10<sup>-_e_</sup>.
-            1. If _scaledRoundedValue_ = 0, then
-              1. Set _significantDigits_ to 1.
-            1. Else,
-              1. Let _l_ be the log-10 of abs(_scaledRoundedValue_).
-              1. Set _significantDigits_ to floor(_l_) + 1.
-          1. Otherwise:
-            1. Set _roundedValue_ be RoundToSignificantDigits(_amountValue_, _significantDigits_, _roundingMode_).
-            1. Let _digitStr_ be the unique decimal string representation of _roundedValue_ without duplicate leading zeroes.
-            1. Set _fractionDigits_ to CountFractionDigits(_digitStr_).
+          1. If _fractionDigits_ is *undefined*, set _fractionDigits_ to CountFractionDigits(_toParse_).
+          1. Else set _roundedValue_ to RoundAmountValueToFractionDigits(_amountValue_, _fractionDigits_, _roundingMode_).
           1. Set _O_.[[Value]] to _roundedValue_.
-          1. Set _O_.[[SignificantDigits]] to _significantDigits_.
           1. Set _O_.[[FractionDigits]] to _fractionDigits_.
         1. Else if _amountValue_ is ~minus-zero~, then
           1. Set _O_.[[Value]] to ~minus-zero~.
-          1. Set _O_.[[SignificantDigits]] to _numDigits_.
           1. Assert: _numDigits_ ≥ 1.
           1. Set _O_.[[FractionDigits]] to _numDigits_ - 1.
         1. Otherwise:
           1. Set _O_.[[Value]] to _amountValue_.
-          1. Set _O_.[[SignificantDigits]] to _numDigits_..
           1. Set _O_.[[FractionDigits]] to 0.
         1. If _unit_ is not *undefined*, set _O_.[[Unit]] to _unit_.
         1. Return _O_.
@@ -466,17 +399,14 @@ location: https://github.com/tc39/proposal-amount/
       1. Let _processedOptions_ be ? GetAmountOptions(_options_).
       1. Let _unit_ be _processedOptions_.[[Unit]].
       1. Let _fractionDigits_ be _processedOptions_.[[FractionDigits]].
-      1. Let _significantDigits_ be _processedOptions_.[[SignificantDigits]].
       1. Let _value_ be _O_.[[Value]].
       1. If _fractionDigits_ is not *undefined*, set _value_ to RoundAmountValueToFractionDigits(_value_, _fractionDigits_).
-      1. Else if _significantDigits_ is not *undefined*, set _value_ to RoundToSignificantDigits(_value_, _significantDigits_).
-      1. Let _N_ be OrdinaryObjectCreate(*"%Amount.prototype%"*, « [[FractionDigits]], [[SignificantDigits]], [[Unit]], [[Value]] »).
+      1. Let _N_ be OrdinaryObjectCreate(*"%Amount.prototype%"*, « [[FractionDigits]], [[Unit]], [[Value]] »).
       1. If _unit_ is not *undefined* and _O_.[[Unit]] is not *undefined*, then
         1. If SameValueNonNumber(_unit_, _O_.[[Unit]]) is *false*, throw a *TypeError* exception.
       1. Set _N_.[[Value]] to _value_.
       1. Set _N_.[[Unit]] to _unit_.
       1. Set _N_.[[FractionDigits]] to ℝ(_fractionDigits_).
-      1. Set _N_.[[SignificantDigits]] to ℝ(_significantDigits_).
       1. Return _N_.
     </emu-alg>
   </emu-clause>

--- a/spec.emu
+++ b/spec.emu
@@ -299,7 +299,7 @@ location: https://github.com/tc39/proposal-amount/
           1. Let _roundingMode_ be ? GetOption(_opts_, *"roundingMode"*, ~string~, « *"ceil"*, *"floor"*, *"expand"*, *"trunc"*, *"halfCeil"*, *"halfFloor"*, *"halfExpand"*, *"halfTrunc"*, *"halfEven"* », *"halfEven"*).
           1. Let _unit_ be ? GetOption(_opts_, *"unit"*, ~string~, ~empty~, *undefined*).
           1. If _fractionDigits_ is not *undefined*, then
-            1. If _fractionDigits_ is not a non-negative integral number, throw a *RangeError* exception.
+            1. If _fractionDigits_ is not an integral number, throw a *RangeError* exception.
           1. Return the Record { [[FractionDigits]]: _fractionDigits_, [[RoundingMode]]: _roundingMode_, [[Units]]: _unit_ }.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
We've seen that there are considerable difficulties when mixing in configurable fraction *and* significant digits in thinking about amounts. We have [adjusted](https://github.com/tc39/proposal-amount/pull/63) the computation of fraction digits so that fraction digits can be negative, and thereby contains more information than merely "how many digits after the dot". We could add significant digits as a computed value (there's an equation it should satisfy with respect to fraction digits, as computed following the updated approach). But here, we simply drop it.