### PR TITLE
Use significant digits only on the way in and out

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -370,7 +370,7 @@ location: https://github.com/tc39/proposal-amount/
           1. Let _unit_ be ? GetOption(_opts_, *"unit"*, ~string~, ~empty~, *undefined*).
           1. If _fractionDigits_ is not *undefined*, then
             1. If _significantDigits_ is not *undefined*, throw a *RangeError* exception.
-            1. If _fractionDigits_ is not a non-negative integral number, throw a *RangeError* exception.
+            1. If _fractionDigits_ is not an integral number, throw a *RangeError* exception.
           1. Else if _significantDigits_ is not *undefined*, then
             1. If _significantDigits_ is not an integral number, throw a *RangeError* exception.
             1. If ℝ(_significantDigits_) < 1, throw a *RangeError* exception.


### PR DESCRIPTION
This is how I think we should handle significant digits. This PR should be though of as on top of https://github.com/tc39/proposal-amount/pull/63.

TL;DR:
- SignificantDigits are not a concept part of the data model. We have ways to convert it to FractionDigits, and we only store FractionDigits.
- for non-zero real numbers SignificantDigits the conversion happens through (from https://github.com/tc39/proposal-amount/issues/54)
  > Let $e$ be the unique integer for which $10^e ≤ |value| < 10^{e + 1}$. Then let $significantDigits = e + fractionDigits + 1$.
- for zero and negative zero, it is $significantDigits = fractionDigits + 1$, matching how Intl already does it, but ensuring that there is at least one significant digit.
- for NaN and infinities they are both 0

Note that we currently don't have a "on the way out" for it. I think it's just that the current spec text doesn't currently have the .fractionDigits/.significantDigits. Once those getters are added, .significantDigits should be implemented as follows:
```
1. Return FractionToSignificantDigits(this.[[Value]], this.[[FractionDigits]])
```

This should match all examples from @waldemarhorwat's table in the _significantDigits_ table from https://github.com/tc39/proposal-amount/issues/54. When it comes to zeroes, it does the following:

| string | fraction digits | significant digits | output I'd expect when stringifying again |
|:--:|:--:|:--:|:--:|
| "0" | 0 | 1 | "0" |
| "0.0000" | 4 | 5 | "0.0000" |
| "00.0000" | 4 | 5 | "0.0000" |
| ".0000" | 4 | 5 | "0.0000" |
| "0e-3" | 3 | 4 | "0.000" |
| "0e3" | -3 | 1 | "0e3" |

I'm on the fence whether "0.0000" and ".0000" should be the same. I like that the 0 prefix is optional, but it'd be open to:
- make .0000 have 4 significant digits
- make in the input .0000 an error

The 0e-3 case is a bit weird, but it matches that for every non-zero digit _x_ 0.00x and xe-3 are equivalent.

Changing the behavior of .0000 and 0e-3 however requires storing both FractionalDigits and SignificantDigits, and they'd not be anymore two sides of the same coin.