### PR TITLE
toString: Fix bug in emitting exponential notation

### DIFF
--- a/intl.emu
+++ b/intl.emu
@@ -152,7 +152,7 @@
         </dd>
       </dl>
       <emu-alg>
-        1. <ins>If _value_ has the [[Value]] and [[FractionDigits]] internal slots, let _primValue_ be RenderAmountValueWithFractionDigits(_value_.[[Value]], _value_.[[FractionDigits]]) else</ins><del>Let</del> <ins>let</ins _primValue_ be ? ToPrimitive(_value_, ~number~).
+        1. <ins>If _value_ has the [[Value]] and [[FractionDigits]] internal slots, let _primValue_ be MVtoDecimalString(_value_.[[Value]], _value_.[[FractionDigits]]) else</ins><del>Let</del> <ins>let</ins _primValue_ be ? ToPrimitive(_value_, ~number~).
         1. If _primValue_ is a BigInt, return ℝ(_primValue_).
         1. If _primValue_ is a String, then
           1. Let _str_ be _primValue_.

--- a/spec.emu
+++ b/spec.emu
@@ -374,6 +374,25 @@ location: https://github.com/tc39/proposal-amount/
         </emu-alg>
       </emu-clause>
 
+      <emu-clause id="sec-amount-significanttofractiondigits" type="abstract operation">
+        <h1>SignificantToFractionDigits (
+          _value_: an Intl mathematical value,
+          _significantDigits_: a positive integer
+        ): an integer
+        </h1>
+        <dl class="header"></dl>
+        <emu-alg>
+          1. If _value_ is one of ~not-a-number~, ~positive-infinity~, or ~negative-infinity~, then
+            1. Return 0.
+          1. If _value_ is one of 0 or ~negative-zero~, then
+            1. Let _integerDigits_ be 1.
+          1. Else,
+            1. Let _integerDigits_ be the smallest integer such that 10<sup>_integerDigits_</sup> > abs(_value_).
+          1. Assert: _significantDigits_ > 0.
+          1. Return _significantDigits_ - _integerDigits_.
+        </emu-alg>
+      </emu-clause>
+
       <emu-clause id="sec-amount-getamountoptions" type="abstract operation">
         <h1>GetAmountOptions (
           _opts_: an Object

--- a/spec.emu
+++ b/spec.emu
@@ -40,7 +40,27 @@ location: https://github.com/tc39/proposal-amount/
           1. If _f_ is not finite, throw a *RangeError* exception.
           1. If _f_ &lt; 0 or _f_ > 100, throw a *RangeError* exception.
           1. If _x_ is not finite, return Number::toString(_x_, 10).
-          1. Return MVtoDecimalString(ℝ(_x_), _f_).
+          1. <ins>Return MVtoDecimalString(ℝ(_x_), _f_).</ins>
+          1. <del>Set _x_ to ℝ(_x_).</del>
+          1. <del>Let _s_ be the empty String.</del>
+          1. <del>If _x_ &lt; 0, then</del>
+            1. <del>Set _s_ to *"-"*.</del>
+            1. <del>Set _x_ to -_x_.</del>
+          1. <del>If _x_ ≥ 10<sup>21</sup>, then</del>
+            1. <del>Let _m_ be ! ToString(𝔽(_x_)).</del>
+          1. <del>Else,</del>
+            1. <del>Let _n_ be an integer for which _n_ / 10<sup>_f_</sup> - _x_ is as close to zero as possible. If there are two such _n_, pick the larger _n_.</del>
+            1. <del>If _n_ = 0, let _m_ be *"0"*. Otherwise, let _m_ be the String value consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).</del>
+            1. <del>If _f_ ≠ 0, then</del>
+              1. <del>Let _k_ be the length of _m_.</del>
+              1. <del>If _k_ ≤ _f_, then</del>
+                1. <del>Let _z_ be the String value consisting of _f_ + 1 - _k_ occurrences of the code unit 0x0030 (DIGIT ZERO).</del>
+                1. <del>Set _m_ to the string-concatenation of _z_ and _m_.</del>
+                1. <del>Set _k_ to _f_ + 1.</del>
+              1. <del>Let _a_ be the first _k_ - _f_ code units of _m_.</del>
+              1. <del>Let _b_ be the other _f_ code units of _m_.</del>
+              1. <del>Set _m_ to the string-concatenation of _a_, *"."*, and _b_.</del>
+          1. <del>Return the string-concatenation of _s_ and _m_.</del>
         </emu-alg>
         <emu-note>
           <p>The output of `toFixed` may be more precise than `toString` for some values because toString only prints enough significant digits to distinguish the number from adjacent Number values. For example,</p>

--- a/spec.emu
+++ b/spec.emu
@@ -265,7 +265,7 @@ location: https://github.com/tc39/proposal-amount/
       <emu-clause id="sec-amount-rendermvwithfractiondigits" type="abstract operation">
         <h1>RenderAmountValueWithFractionDigits (
           _v_: an Intl mathematical value,
-          _numDigits_: an integer
+          _fractionDigits_: an integer
         ): a String
         </h1>
         <dl class="header">
@@ -277,28 +277,28 @@ location: https://github.com/tc39/proposal-amount/
           1. If _v_ is ~negative-infinity~, return *"-Infinity"*.
           1. If _v_ is ~positive-infinity~, return *"Infinity"*.
           1. If _v_ is ~minus-zero~, then
-            1. If _numDigits_ < 0, then
-              1. Let _exp_ be the unique string representation of -_numDigits_ in base 10 without duplicate leading zeros.
+            1. If _fractionDigits_ < 0, then
+              1. Let _exp_ be the unique string representation of -_fractionDigits_ in base 10 without duplicate leading zeros.
               1. Return the string-concatenation of *"0"*, *"e"*, and _exp_.
             1. Otherwise:
-              1. Let _trailingZeroes_ be *"0"* repeated _numDigits_ times.
+              1. Let _trailingZeroes_ be *"0"* repeated _fractionDigits_ times.
               1. Let _z_ be *"-0"*.
-              1. If _numDigits_ = 0, return _z_.
+              1. If _fractionDigits_ = 0, return _z_.
               1. Otherwise, return the string-concatenation of _z_, *"."* and _trailingZeroes_.
           1. If _v_ < 0, let _prefix_ be *"-"*, else let _prefix_ be "".
           1. If _v_ < 0, set _v_ to -_v_.
           1. Let _e_ be the smallest non-negative integer such that _v_ × 10<sup>-_e_</sup> is an integer.
           1. Let _s_ be the unique decimal string representation of _v_ without duplicate leading zeroes.
-          1. If _e_ < _numDigits_, then
-            1. If _v_ is an integer, return the string-concatenation of _prefix, _s_, *"."*, and *"0"* repeated _numDigits_ times.
-            1. Otherwise, return the string-concatenation of _prefix_, _s_ and *"0"* repeated _numDigits_ - _e_ times.
-          1. Else if 0 ≤ _numDigits_, then
-            1. Return the string-concatenation of _prefix, _s_ and *"0"* repeated _e_ - _numDigits_ times.
+          1. If _e_ < _fractionDigits_, then
+            1. If _v_ is an integer, return the string-concatenation of _prefix, _s_, *"."*, and *"0"* repeated _fractionDigits_ times.
+            1. Otherwise, return the string-concatenation of _prefix_, _s_ and *"0"* repeated _fractionDigits_ - _e_ times.
+          1. Else if 0 ≤ _fractionDigits_, then
+            1. Return the string-concatenation of _prefix, _s_ and *"0"* repeated _e_ - _fractionDigits_ times.
           1. Otherwise:
             1. Let _firstDigit_ be the substring of _s_ from 0 to 1.
             1. Let _p_ be the unique integer such that 1 ≤ _v_ × 10<sup>_p_</sup> < 10.
-            1. Assert: _numDigits_ < 0.
-            1. Let _n_ be _p_ + _numDigits_.
+            1. Assert: _fractionDigits_ < 0.
+            1. Let _n_ be _p_ + _fractionDigits_.
             1. Assert: _n_ < 0.
             1. Let _exp_ be the unique string representation of -_n_ in base-10 without duplicate leading zeros.
             1. Let _remainingDigits_ be the substring of _s_ from 1 to _n_.

--- a/spec.emu
+++ b/spec.emu
@@ -290,8 +290,7 @@ location: https://github.com/tc39/proposal-amount/
             1. Return the string-concatenation of _prefix, _s_ and *"0"* repeated _e_ - _fractionDigits_ times.
           1. Otherwise:
             1. Let _firstDigit_ be the substring of _s_ from 0 to 1.
-            1. Let _p_ be the unique integer such that 1 ≤ _v_ × 10<sup>_p_</sup> < 10.
-            1. Assert: _fractionDigits_ < 0.
+            1. If _v_ = 0, let _p_ be 0, else let _p_ be the unique integer such that 1 ≤ _v_ × 10<sup>_p_</sup> < 10.
             1. Let _n_ be _p_ + _fractionDigits_.
             1. Assert: _n_ < 0.
             1. Let _exp_ be the unique string representation of -_n_ in base-10 without duplicate leading zeros.

--- a/spec.emu
+++ b/spec.emu
@@ -302,6 +302,7 @@ location: https://github.com/tc39/proposal-amount/
           1. Otherwise:
             1. Let _firstDigit_ be the substring of _s_ from 0 to 1.
             1. Let _p_ be the unique integer such that 1 ≤ _rounded_ × 10<sup>_p_</sup> < 10.
+            1. Assert: _numDigits_ < 0.
             1. Let _n_ be _p_ + _numDigits_.
             1. Assert: _n_ < 0.
             1. Let _exp_ be the unique string representation of -_n_ in base-10 without duplicate leading zeros.

--- a/spec.emu
+++ b/spec.emu
@@ -284,7 +284,7 @@ location: https://github.com/tc39/proposal-amount/
           1. Let _e_ be the smallest non-negative integer such that _v_ × 10<sup>-_e_</sup> is an integer.
           1. Let _s_ be the unique decimal string representation of _v_ without duplicate leading zeroes.
           1. If _e_ < _fractionDigits_, then
-            1. If _v_ is an integer, return the string-concatenation of _prefix, _s_, *"."*, and *"0"* repeated _fractionDigits_ times.
+            1. If _v_ is an integer, return the string-concatenation of _prefix_, _s_, *"."*, and *"0"* repeated _fractionDigits_ times.
             1. Otherwise, return the string-concatenation of _prefix_, _s_ and *"0"* repeated _fractionDigits_ - _e_ times.
           1. Else if 0 ≤ _fractionDigits_, then
             1. Return the string-concatenation of _prefix, _s_ and *"0"* repeated _e_ - _fractionDigits_ times.

--- a/spec.emu
+++ b/spec.emu
@@ -277,13 +277,8 @@ location: https://github.com/tc39/proposal-amount/
           1. If _v_ is ~negative-infinity~, return *"-Infinity"*.
           1. If _v_ is ~positive-infinity~, return *"Infinity"*.
           1. If _v_ is ~minus-zero~, then
-            1. If _fractionDigits_ < 0, then
-              1. Let _exp_ be the unique string representation of -_fractionDigits_ in base 10 without duplicate leading zeros.
-              1. Return the string-concatenation of *"-0"*, *"e"*, and _exp_.
-            1. Otherwise:
-              1. If _fractionDigits_ = 0, return *"-0"*.
-              1. Let _trailingZeroes_ be *"0"* repeated _fractionDigits_ times.
-              1. Otherwise, return the string-concatenation of *"-0"*, *"."* and _trailingZeroes_.
+            1. Let _s_ be RenderAmountValueWithFractionDigits(0, _fractionDigits_:).
+            1. Return the string-concatenation of *"-"* and _s_.
           1. If _v_ < 0, let _prefix_ be *"-"*, else let _prefix_ be "".
           1. If _v_ < 0, set _v_ to -_v_.
           1. Let _e_ be the smallest non-negative integer such that _v_ × 10<sup>-_e_</sup> is an integer.

--- a/spec.emu
+++ b/spec.emu
@@ -282,7 +282,7 @@ location: https://github.com/tc39/proposal-amount/
           1. If _v_ < 0, let _prefix_ be *"-"*, else let _prefix_ be "".
           1. If _v_ < 0, set _v_ to -_v_.
           1. Let _e_ be the smallest non-negative integer such that _v_ × 10<sup>-_e_</sup> is an integer.
-          1. Let _s_ be the unique decimal string representation of _v_ without duplicate leading zeroes.
+          1. If _v_ = 0, let _s_ be *"0"*, else let _s_ be the unique decimal string representation of _v_ that either starts with "0." or does not start with "0".
           1. If _e_ < _fractionDigits_, then
             1. If _v_ is an integer, return the string-concatenation of _prefix_, _s_, *"."*, and *"0"* repeated _fractionDigits_ times.
             1. Otherwise, return the string-concatenation of _prefix_, _s_ and *"0"* repeated _fractionDigits_ - _e_ times.

--- a/spec.emu
+++ b/spec.emu
@@ -265,13 +265,12 @@ location: https://github.com/tc39/proposal-amount/
       <emu-clause id="sec-amount-rendermvwithfractiondigits" type="abstract operation">
         <h1>RenderAmountValueWithFractionDigits (
           _v_: an Intl mathematical value,
-          _numDigits_: an integer,
-          optional _roundingMode_: a rounding mode
+          _numDigits_: an integer
         ): a String
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It renders the given Intl mathematical value with a given number of fractional digits, rounding, if necessary, using the given rounding mode, which, if missing, is *"halfEven"*.</dd>
+          <dd>It renders the given Intl mathematical value with a given number of fractional digits</dd>
         </dl>
         <emu-alg>
           1. If _v_ is ~not-a-number~, return *"NaN"*.
@@ -286,14 +285,10 @@ location: https://github.com/tc39/proposal-amount/
               1. Let _z_ be *"-0"*.
               1. If _numDigits_ = 0, return _z_.
               1. Otherwise, return the string-concatenation of _z_, *"."* and _trailingZeroes_.
-          1. If _roundingMode_ is *undefined*, set _roundingMode_ to *"halfEven"*.
           1. If _v_ < 0, let _prefix_ be *"-"*, else let _prefix_ be "".
-          1. If _v_ < 0, then
-            1. Set _v_ to -_v_.
-            1. Set _roundingMode_ to ReverseRoundingMode(_roundingMode_).
-          1. Let _rounded_ be ApplyRoundingModeToPositive(_v_ × 10<sup>_numDigits_</sup>, _roundingMode_).
-          1. Let _e_ be the smallest non-negative integer such that _rounded_ × 10<sup>-_e_</sup> is an integer.
-          1. Let _s_ be the unique decimal string representation of _rounded_ without duplicate leading zeroes.
+          1. If _v_ < 0, set _v_ to -_v_.
+          1. Let _e_ be the smallest non-negative integer such that _v_ × 10<sup>-_e_</sup> is an integer.
+          1. Let _s_ be the unique decimal string representation of _v_ without duplicate leading zeroes.
           1. If _e_ < _numDigits_, then
             1. If _v_ is an integer, return the string-concatenation of _prefix, _s_, *"."*, and *"0"* repeated _numDigits_ times.
             1. Otherwise, return the string-concatenation of _prefix_, _s_ and *"0"* repeated _numDigits_ - _e_ times.
@@ -301,7 +296,7 @@ location: https://github.com/tc39/proposal-amount/
             1. Return the string-concatenation of _prefix, _s_ and *"0"* repeated _e_ - _numDigits_ times.
           1. Otherwise:
             1. Let _firstDigit_ be the substring of _s_ from 0 to 1.
-            1. Let _p_ be the unique integer such that 1 ≤ _rounded_ × 10<sup>_p_</sup> < 10.
+            1. Let _p_ be the unique integer such that 1 ≤ _v_ × 10<sup>_p_</sup> < 10.
             1. Assert: _numDigits_ < 0.
             1. Let _n_ be _p_ + _numDigits_.
             1. Assert: _n_ < 0.

--- a/spec.emu
+++ b/spec.emu
@@ -292,25 +292,21 @@ location: https://github.com/tc39/proposal-amount/
             1. Set _v_ to -_v_.
             1. Set _roundingMode_ to ReverseRoundingMode(_roundingMode_).
           1. Let _rounded_ be ApplyRoundingModeToPositive(_v_ × 10<sup>_numDigits_</sup>, _roundingMode_).
-          1. Let _e_ be the smallest non-negative integer such that _rounded_ × 10<sup>-_numDigits_</sup> is an integer.
+          1. Let _e_ be the smallest non-negative integer such that _rounded_ × 10<sup>-_e_</sup> is an integer.
           1. Let _s_ be the unique decimal string representation of _rounded_ without duplicate leading zeroes.
-          1. If _numDigits_ > _e_, then
+          1. If _e_ < numDigits_, then
             1. If _v_ is an integer, return the string-concatenation of _prefix, _s_, *"."*, and *"0"* repeated _numDigits_ times.
             1. Otherwise, return the string-concatenation of _prefix_, _s_ and *"0"* repeated _numDigits_ - _e_ times.
-          1. If 0 < _numDigits_, then
+          1. Else if 0 < _numDigits_, then
             1. Return the string-concatenation of _prefix, _s_ and *"0"* repeated _e_ - _numDigits_ times.
           1. Otherwise:
-            1. Assert: _rounded_ is an integer.
             1. Let _firstDigit_ be the substring of _s_ from 0 to 1.
             1. Let _p_ be the unique integer such that 1 ≤ _rounded_ × 10<sup>_p_</sup> < 10.
             1. Let _n_ be _p_ + _numDigits_.
-            1. Assert: _n_ ≥ 0.
-            1. Let _exp_ be the unique string representation of _n_ in base-10 without duplicate leading zeros.
-            1. If _n_ = 0, then
-              1. Return the string-concatenation of _s_, *"e"*, and _exp_.
-            1. Otherwise:
-              1. Let _remainingDigits_ be the substring of _s_ from 1 to _n_.
-              1. Return the string-concatenation of _firstDigit_, *"."*, _remainingDigits_, *"e"*, and _exp_.
+            1. Assert: _n_ < 0.
+            1. Let _exp_ be the unique string representation of -_n_ in base-10 without duplicate leading zeros.
+            1. Let _remainingDigits_ be the substring of _s_ from 1 to _n_.
+            1. Return the string-concatenation of _firstDigit_, *"."*, _remainingDigits_, *"e"*, and _exp_.
         </emu-alg>
       </emu-clause>
 

--- a/spec.emu
+++ b/spec.emu
@@ -294,7 +294,7 @@ location: https://github.com/tc39/proposal-amount/
           1. Let _rounded_ be ApplyRoundingModeToPositive(_v_ × 10<sup>_numDigits_</sup>, _roundingMode_).
           1. Let _e_ be the smallest non-negative integer such that _rounded_ × 10<sup>-_e_</sup> is an integer.
           1. Let _s_ be the unique decimal string representation of _rounded_ without duplicate leading zeroes.
-          1. If _e_ < numDigits_, then
+          1. If _e_ < _numDigits_, then
             1. If _v_ is an integer, return the string-concatenation of _prefix, _s_, *"."*, and *"0"* repeated _numDigits_ times.
             1. Otherwise, return the string-concatenation of _prefix_, _s_ and *"0"* repeated _numDigits_ - _e_ times.
           1. Else if 0 < _numDigits_, then

--- a/spec.emu
+++ b/spec.emu
@@ -20,100 +20,69 @@ location: https://github.com/tc39/proposal-amount/
   </ul>
 </emu-intro>
 
-<emu-clause id="sec-ecmascript-data-types-and-values">
-  <h1>ECMAScript Data Types and Values</h1>
-  <emu-clause id="sec-ecmascript-language-types">
-    <h1>ECMAScript Language Types</h1>
-    <emu-clause id="sec-numeric-types">
-      <h1>Numeric Types</h1>
-      <emu-clause id="sec-ecmascript-language-types-number-type">
-        <h1>The Number Type</h1>
-        <emu-clause id="" type="abstract operation">
-          <h1>MVToNonExponentialString(
-            _x_ : a mathematical value,
-            _radix_ : an integer in the inclusive interval from 2 to 36
-           ): a String
-           </h1>
-          <dl class="header">
-            <dt>description</dt>
-            <dd>It represents _x_ as a String using a positional numeral system with radix _radix_. The digits used in the representation of a number using radix _r_ are taken from the first _r_ code units of *"0123456789abcdefghijklmnopqrstuvwxyz"* in order. The representation of numbers with magnitude greater than or equal to *1*<sub>𝔽</sub> never includes leading zeroes.</dd>
-          </dl>
-          <emu-alg>
-            1. If _radix_ ≠ 10 or _n_ is in the inclusive interval from -5 to 21, then
-              1. If _n_ ≥ _k_, then
-                1. Return the string-concatenation of:
-                  * the code units of the _k_ digits of the representation of _s_ using radix _radix_
-                  * _n_ - _k_ occurrences of the code unit 0x0030 (DIGIT ZERO)
-              1. Else if _n_ > 0, then
-                1. Return the string-concatenation of:
-                  * the code units of the most significant _n_ digits of the representation of _s_ using radix _radix_
-                  * the code unit 0x002E (FULL STOP)
-                  * the code units of the remaining _k_ - _n_ digits of the representation of _s_ using radix _radix_
-              1. Else,
-                1. Assert: _n_ ≤ 0.
-                1. Return the string-concatenation of:
-                  * the code unit 0x0030 (DIGIT ZERO)
-                  * the code unit 0x002E (FULL STOP)
-                  * -_n_ occurrences of the code unit 0x0030 (DIGIT ZERO)
-                  * the code units of the _k_ digits of the representation of _s_ using radix _radix_
-          </emu-alg>
-        </emu-clause>
-        <emu-clause id="sec-numeric-types-number-tostring" type="numeric method" oldids="sec-tostring-applied-to-the-number-type">
+<emu-clause id="sec-numbers-and-dates">
+  <h1>Numbers and Dates</h1>
+  <emu-clause id="sec-number-objects">
+    <h1>Number Objects</h1>
+    <emu-clause id="sec-properties-of-the-number-prototype-object">
+      <h1>Properties of the Number Prototype Object</h1>
+    </emu-clause>
+      <emu-clause id="sec-number.prototype.tofixed">
+        <h1>Number.prototype.toFixed ( _fractionDigits_ )</h1>
+        <emu-note>
+          <p>This method returns a String containing this Number value represented in decimal fixed-point notation with _fractionDigits_ digits after the decimal point. If _fractionDigits_ is *undefined*, 0 is assumed.</p>
+        </emu-note>
+        <p>It performs the following steps when called:</p>
+        <emu-alg>
+          1. Let _x_ be ? ThisNumberValue(*this* value).
+          1. Let _f_ be ? ToIntegerOrInfinity(_fractionDigits_).
+          1. Assert: If _fractionDigits_ is *undefined*, then _f_ is 0.
+          1. If _f_ is not finite, throw a *RangeError* exception.
+          1. If _f_ &lt; 0 or _f_ > 100, throw a *RangeError* exception.
+          1. If _x_ is not finite, return Number::toString(_x_, 10).
+          1. Return MVtoDecimalString(ℝ(_x_), _f_).
+        </emu-alg>
+        <emu-note>
+          <p>The output of `toFixed` may be more precise than `toString` for some values because toString only prints enough significant digits to distinguish the number from adjacent Number values. For example,</p>
+          <p>
+            `(1000000000000000128).toString()` returns *"1000000000000000100"*, while<br>
+            `(1000000000000000128).toFixed(0)` returns *"1000000000000000128"*.
+          </p>
+        </emu-note>
+        <emu-clause id="sec-mvtodecimalstring" type="abstract operation">
           <h1>
-            Number::toString (
-              _x_: a Number,
-              _radix_: an integer in the inclusive interval from 2 to 36,
+            MVtoDecimalString (
+              _x_: a mathematical value,
+              _fractionDigits_ : a non-negative integer
             ): a String
           </h1>
           <dl class="header">
             <dt>description</dt>
-            <dd>It represents _x_ as a String using a positional numeral system with radix _radix_. The digits used in the representation of a number using radix _r_ are taken from the first _r_ code units of *"0123456789abcdefghijklmnopqrstuvwxyz"* in order. The representation of numbers with magnitude greater than or equal to *1*<sub>𝔽</sub> never includes leading zeroes.</dd>
+            <dd>It renders the given Intl mathematical value with a given number of fractional digits</dd>
           </dl>
           <emu-alg>
-            1. If _x_ is *NaN*, return *"NaN"*.
-            1. If _x_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *"0"*.
-            1. If _x_ &lt; *-0*<sub>𝔽</sub>, return the string-concatenation of *"-"* and Number::toString(-_x_, _radix_).
-            1. If _x_ is *+∞*<sub>𝔽</sub>, return *"Infinity"*.
-            1. [id="step-number-tostring-intermediate-values"] Let _n_, _k_, and _s_ be integers such that _k_ ≥ 1, _radix_<sup>_k_ - 1</sup> ≤ _s_ &lt; _radix_<sup>_k_</sup>, 𝔽(_s_ × _radix_<sup>_n_ - _k_</sup>) is _x_, and _k_ is as small as possible. Note that _k_ is the number of digits in the representation of _s_ using radix _radix_, that _s_ is not divisible by _radix_, and that the least significant digit of _s_ is not necessarily uniquely determined by these criteria.
-            1. If _radix_ ≠ 10 or _n_ is in the inclusive interval from -5 to 21, then
-              1. If _n_ ≥ _k_, then
-                1. Return the string-concatenation of:
-                  * the code units of the _k_ digits of the representation of _s_ using radix _radix_
-                  * _n_ - _k_ occurrences of the code unit 0x0030 (DIGIT ZERO)
-              1. Else if _n_ > 0, then
-                1. Return the string-concatenation of:
-                  * the code units of the most significant _n_ digits of the representation of _s_ using radix _radix_
-                  * the code unit 0x002E (FULL STOP)
-                  * the code units of the remaining _k_ - _n_ digits of the representation of _s_ using radix _radix_
-              1. Else,
-                1. Assert: _n_ ≤ 0.
-                1. Return the string-concatenation of:
-                  * the code unit 0x0030 (DIGIT ZERO)
-                  * the code unit 0x002E (FULL STOP)
-                  * -_n_ occurrences of the code unit 0x0030 (DIGIT ZERO)
-                  * the code units of the _k_ digits of the representation of _s_ using radix _radix_
-            1. NOTE: In this case, the input will be represented using scientific E notation, such as `1.2e+3`.
-            1. Assert: _radix_ is 10.
-            1. If _n_ &lt; 0, then
-              1. Let _exponentSign_ be the code unit 0x002D (HYPHEN-MINUS).
+            1. Let _s_ be the empty String.
+            1. If _x_ &lt; 0, then
+              1. Set _s_ to *"-"*.
+              1. Set _x_ to -_x_.
+            1. If _x_ ≥ 10<sup>21</sup>, then
+              1. Let _m_ be ! ToString(𝔽(_x_)).
             1. Else,
-              1. Let _exponentSign_ be the code unit 0x002B (PLUS SIGN).
-            1. If _k_ = 1, then
-              1. Return the string-concatenation of:
-                * the code unit of the single digit of _s_
-                * the code unit 0x0065 (LATIN SMALL LETTER E)
-                * _exponentSign_
-                * the code units of the decimal representation of abs(_n_ - 1)
-            1. Return the string-concatenation of:
-              * the code unit of the most significant digit of the decimal representation of _s_
-              * the code unit 0x002E (FULL STOP)
-              * the code units of the remaining _k_ - 1 digits of the decimal representation of _s_
-              * the code unit 0x0065 (LATIN SMALL LETTER E)
-              * _exponentSign_
-              * the code units of the decimal representation of abs(_n_ - 1)
+              1. Let _n_ be an integer for which _n_ / 10<sup>_fractionDigits_</sup> - _x_ is as close to zero as possible. If there are two such _n_, pick the larger _n_.
+              1. If _n_ = 0, let _m_ be *"0"*. Otherwise, let _m_ be the String value consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
+              1. If _fractionDigits_ ≠ 0, then
+                1. Let _k_ be the length of _m_.
+                1. If _k_ ≤ _fractionDigits_, then
+                  1. Let _z_ be the String value consisting of _fractionDigits_ + 1 - _k_ occurrences of the code unit 0x0030 (DIGIT ZERO).
+                  1. Set _m_ to the string-concatenation of _z_ and _m_.
+                  1. Set _k_ to _fractionDigits_ + 1.
+                1. Let _a_ be the first _k_ - _fractionDigits_ code units of _m_.
+                1. Let _b_ be the other _fractionDigits_ code units of _m_.
+                1. Set _m_ to the string-concatenation of _a_, *"."*, and _b_.
+            1. Return the string-concatenation of _s_ and _m_.
           </emu-alg>
+        </emu-clause>
       </emu-clause>
-    </emu-clause>
   </emu-clause>
 </emu-clause>
 
@@ -359,79 +328,29 @@ location: https://github.com/tc39/proposal-amount/
         </emu-alg>
       </emu-clause>
 
-      <emu-clause id="sec-amount-rendermvwithfractiondigits" type="abstract operation">
-        <h1>RenderAmountValueWithFractionDigits (
-          _v_: an Intl mathematical value,
-          _fractionDigits_: an integer
-        ): a String
+      <emu-clause id="sec-amount-roundtosignificantdigits" type="abstract operation">
+        <h1>RoundToSignificantDigits (
+          _v_: a mathematical value,
+          _n_: a non-negative integer,
+          optional _roundingMode_: a rounding mode
+        ): a mathematical value
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It renders the given Intl mathematical value with a given number of fractional digits</dd>
+          <dd>It computes the closest approximation to a given mathematical value that has at most the given number of significant digits, rounding (if necessary) according to the given rounding mode.</dd>
         </dl>
         <emu-alg>
-          1. If _v_ is ~not-a-number~, return *"NaN"*.
-          1. If _v_ is ~negative-infinity~, return *"-Infinity"*.
-          1. If _v_ is ~positive-infinity~, return *"Infinity"*.
-          1. If _v_ is ~minus-zero~, then
-            1. Let _s_ be RenderAmountValueWithFractionDigits(0, _fractionDigits_:).
-            1. Return the string-concatenation of *"-"* and _s_.
-          1. If _v_ < 0, let _prefix_ be *"-"*, else let _prefix_ be "".
-          1. If _v_ < 0, set _v_ to -_v_.
-          1. Let _e_ be the smallest non-negative integer such that _v_ × 10<sup>-_e_</sup> is an integer.
-          1. If _v_ = 0, let _s_ be *"0"*, else let _s_ be the unique decimal string representation of _v_ that either starts with "0." or does not start with "0".
-          1. If _e_ < _fractionDigits_, then
-            1. If _v_ is an integer, return the string-concatenation of _prefix_, _s_, *"."*, and *"0"* repeated _fractionDigits_ times.
-            1. Otherwise, return the string-concatenation of _prefix_, _s_ and *"0"* repeated _fractionDigits_ - _e_ times.
-          1. Else if 0 ≤ _fractionDigits_, then
-            1. Return the string-concatenation of _prefix, _s_ and *"0"* repeated _e_ - _fractionDigits_ times.
-          1. Otherwise:
-            1. Let _firstDigit_ be the substring of _s_ from 0 to 1.
-            1. If _v_ = 0, let _p_ be 0, else let _p_ be the unique integer such that 1 ≤ _v_ × 10<sup>_p_</sup> < 10.
-            1. Let _n_ be _p_ + _fractionDigits_.
-            1. Assert: _n_ < 0.
-            1. Let _exp_ be the unique string representation of -_n_ in base-10 without duplicate leading zeros.
-            1. Let _remainingDigits_ be the substring of _s_ from 1 to _n_.
-            1. Return the string-concatenation of _firstDigit_, *"."*, _remainingDigits_, *"e"*, and _exp_.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-amount-FractionToSignificantDigits" type="abstract operation">
-        <h1>FractionToSignificantDigits (
-          _value_: an Intl mathematical value,
-          _fractionDigits_: an integer
-        ): a non-negative integer
-        </h1>
-        <dl class="header"></dl>
-        <emu-alg>
-          1. If _value_ is one of ~not-a-number~, ~positive-infinity~, or ~negative-infinity~, then
-            1. Return 0.
-          1. If _value_ is one of 0 or ~negative-zero~, then
-            1. If _fractionDigits_ < 0, return 1.
-            1. Let _integerDigits_ be 1.
-          1. Else,
-            1. Let _integerDigits_ be the smallest integer such that 10<sup>_integerDigits_</sup> > abs(_value_).
-          1. Assert: _integerDigits_ + _fractionDigits_ > 0.
-          1. Return _integerDigits_ + _fractionDigits_.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-amount-SignificantToFractionDigits" type="abstract operation">
-        <h1>SignificantToFractionDigits (
-          _value_: an Intl mathematical value,
-          _significantDigits_: a positive integer
-        ): an integer
-        </h1>
-        <dl class="header"></dl>
-        <emu-alg>
-          1. If _value_ is one of ~not-a-number~, ~positive-infinity~, or ~negative-infinity~, then
-            1. Return 0.
-          1. If _value_ is one of 0 or ~negative-zero~, then
-            1. Let _integerDigits_ be 1.
-          1. Else,
-            1. Let _integerDigits_ be the smallest integer such that 10<sup>_integerDigits_</sup> > abs(_value_).
-          1. Assert: _significantDigits_ > 0.
-          1. Return _significantDigits_ - _integerDigits_.
+          1. If _roundingMode_ is *undefined*, set _roundingMode_ to *"halfEven"*.
+          1. If _v_ = 0, return 0.
+          1. If v &lt; 0, then
+            1. Let _reverseRoundingMode_ be ReverseRoundingMode(_roundingMode_).
+            1. Let _d_ be RoundToSignificantDigits(–_v_, _n_, _reverseRoundingMode_).
+            1. Return –_d_.
+          1. Let _e_ be the unique integer such that 10<sup>_e_</sup> ≤ _v_ < 10<sup>_e_+1</sup>.
+          1. Let _pow_ be _e_ - _n_.
+          1. Let _m_ be _v_ × 10<sup>–_pow_</sup>.
+          1. Let _rounded_ be ApplyRoundingModeToPositive(_m_, _roundingMode_).
+          1. Return _rounded_ × 10<sup>_n_ + _e_</sup>.
         </emu-alg>
       </emu-clause>
 
@@ -563,7 +482,7 @@ location: https://github.com/tc39/proposal-amount/
       1. Let _u_ be _O_.[[Unit]].
       1. Let _v_ be _O_.[[Value]].
       1. Let _fractionDigits_ be _O_.[[FractionDigits]].
-      1. Let _s_ be RenderAmountValueWithFractionDigits(_v_, _fractionDigits_).
+      1. Let _s_ be MVtoDecimalString(_v_, _fractionDigits_).
       1. If _displayUnit_ is *"never"*, return _s_.
       1. If _u_ is *undefined*, then
         1. If _displayUnit_ is *"always"*, return the string-concatenation of _s_ and *"[1]"*.

--- a/spec.emu
+++ b/spec.emu
@@ -297,7 +297,7 @@ location: https://github.com/tc39/proposal-amount/
           1. If _e_ < _numDigits_, then
             1. If _v_ is an integer, return the string-concatenation of _prefix, _s_, *"."*, and *"0"* repeated _numDigits_ times.
             1. Otherwise, return the string-concatenation of _prefix_, _s_ and *"0"* repeated _numDigits_ - _e_ times.
-          1. Else if 0 < _numDigits_, then
+          1. Else if 0 ≤ _numDigits_, then
             1. Return the string-concatenation of _prefix, _s_ and *"0"* repeated _e_ - _numDigits_ times.
           1. Otherwise:
             1. Let _firstDigit_ be the substring of _s_ from 0 to 1.

--- a/spec.emu
+++ b/spec.emu
@@ -20,6 +20,103 @@ location: https://github.com/tc39/proposal-amount/
   </ul>
 </emu-intro>
 
+<emu-clause id="sec-ecmascript-data-types-and-values">
+  <h1>ECMAScript Data Types and Values</h1>
+  <emu-clause id="sec-ecmascript-language-types">
+    <h1>ECMAScript Language Types</h1>
+    <emu-clause id="sec-numeric-types">
+      <h1>Numeric Types</h1>
+      <emu-clause id="sec-ecmascript-language-types-number-type">
+        <h1>The Number Type</h1>
+        <emu-clause id="" type="abstract operation">
+          <h1>MVToNonExponentialString(
+            _x_ : a mathematical value,
+            _radix_ : an integer in the inclusive interval from 2 to 36
+           ): a String
+           </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It represents _x_ as a String using a positional numeral system with radix _radix_. The digits used in the representation of a number using radix _r_ are taken from the first _r_ code units of *"0123456789abcdefghijklmnopqrstuvwxyz"* in order. The representation of numbers with magnitude greater than or equal to *1*<sub>𝔽</sub> never includes leading zeroes.</dd>
+          </dl>
+          <emu-alg>
+            1. If _radix_ ≠ 10 or _n_ is in the inclusive interval from -5 to 21, then
+              1. If _n_ ≥ _k_, then
+                1. Return the string-concatenation of:
+                  * the code units of the _k_ digits of the representation of _s_ using radix _radix_
+                  * _n_ - _k_ occurrences of the code unit 0x0030 (DIGIT ZERO)
+              1. Else if _n_ > 0, then
+                1. Return the string-concatenation of:
+                  * the code units of the most significant _n_ digits of the representation of _s_ using radix _radix_
+                  * the code unit 0x002E (FULL STOP)
+                  * the code units of the remaining _k_ - _n_ digits of the representation of _s_ using radix _radix_
+              1. Else,
+                1. Assert: _n_ ≤ 0.
+                1. Return the string-concatenation of:
+                  * the code unit 0x0030 (DIGIT ZERO)
+                  * the code unit 0x002E (FULL STOP)
+                  * -_n_ occurrences of the code unit 0x0030 (DIGIT ZERO)
+                  * the code units of the _k_ digits of the representation of _s_ using radix _radix_
+          </emu-alg>
+        </emu-clause>
+        <emu-clause id="sec-numeric-types-number-tostring" type="numeric method" oldids="sec-tostring-applied-to-the-number-type">
+          <h1>
+            Number::toString (
+              _x_: a Number,
+              _radix_: an integer in the inclusive interval from 2 to 36,
+            ): a String
+          </h1>
+          <dl class="header">
+            <dt>description</dt>
+            <dd>It represents _x_ as a String using a positional numeral system with radix _radix_. The digits used in the representation of a number using radix _r_ are taken from the first _r_ code units of *"0123456789abcdefghijklmnopqrstuvwxyz"* in order. The representation of numbers with magnitude greater than or equal to *1*<sub>𝔽</sub> never includes leading zeroes.</dd>
+          </dl>
+          <emu-alg>
+            1. If _x_ is *NaN*, return *"NaN"*.
+            1. If _x_ is either *+0*<sub>𝔽</sub> or *-0*<sub>𝔽</sub>, return *"0"*.
+            1. If _x_ &lt; *-0*<sub>𝔽</sub>, return the string-concatenation of *"-"* and Number::toString(-_x_, _radix_).
+            1. If _x_ is *+∞*<sub>𝔽</sub>, return *"Infinity"*.
+            1. [id="step-number-tostring-intermediate-values"] Let _n_, _k_, and _s_ be integers such that _k_ ≥ 1, _radix_<sup>_k_ - 1</sup> ≤ _s_ &lt; _radix_<sup>_k_</sup>, 𝔽(_s_ × _radix_<sup>_n_ - _k_</sup>) is _x_, and _k_ is as small as possible. Note that _k_ is the number of digits in the representation of _s_ using radix _radix_, that _s_ is not divisible by _radix_, and that the least significant digit of _s_ is not necessarily uniquely determined by these criteria.
+            1. If _radix_ ≠ 10 or _n_ is in the inclusive interval from -5 to 21, then
+              1. If _n_ ≥ _k_, then
+                1. Return the string-concatenation of:
+                  * the code units of the _k_ digits of the representation of _s_ using radix _radix_
+                  * _n_ - _k_ occurrences of the code unit 0x0030 (DIGIT ZERO)
+              1. Else if _n_ > 0, then
+                1. Return the string-concatenation of:
+                  * the code units of the most significant _n_ digits of the representation of _s_ using radix _radix_
+                  * the code unit 0x002E (FULL STOP)
+                  * the code units of the remaining _k_ - _n_ digits of the representation of _s_ using radix _radix_
+              1. Else,
+                1. Assert: _n_ ≤ 0.
+                1. Return the string-concatenation of:
+                  * the code unit 0x0030 (DIGIT ZERO)
+                  * the code unit 0x002E (FULL STOP)
+                  * -_n_ occurrences of the code unit 0x0030 (DIGIT ZERO)
+                  * the code units of the _k_ digits of the representation of _s_ using radix _radix_
+            1. NOTE: In this case, the input will be represented using scientific E notation, such as `1.2e+3`.
+            1. Assert: _radix_ is 10.
+            1. If _n_ &lt; 0, then
+              1. Let _exponentSign_ be the code unit 0x002D (HYPHEN-MINUS).
+            1. Else,
+              1. Let _exponentSign_ be the code unit 0x002B (PLUS SIGN).
+            1. If _k_ = 1, then
+              1. Return the string-concatenation of:
+                * the code unit of the single digit of _s_
+                * the code unit 0x0065 (LATIN SMALL LETTER E)
+                * _exponentSign_
+                * the code units of the decimal representation of abs(_n_ - 1)
+            1. Return the string-concatenation of:
+              * the code unit of the most significant digit of the decimal representation of _s_
+              * the code unit 0x002E (FULL STOP)
+              * the code units of the remaining _k_ - 1 digits of the decimal representation of _s_
+              * the code unit 0x0065 (LATIN SMALL LETTER E)
+              * _exponentSign_
+              * the code units of the decimal representation of abs(_n_ - 1)
+          </emu-alg>
+      </emu-clause>
+    </emu-clause>
+  </emu-clause>
+</emu-clause>
+
 <emu-clause id="sec-the-amount-object">
   <h1>The Amount Object</h1>
   <emu-intro id="sec-amount-intro">

--- a/spec.emu
+++ b/spec.emu
@@ -279,7 +279,7 @@ location: https://github.com/tc39/proposal-amount/
           1. If _v_ is ~minus-zero~, then
             1. If _fractionDigits_ < 0, then
               1. Let _exp_ be the unique string representation of -_fractionDigits_ in base 10 without duplicate leading zeros.
-              1. Return the string-concatenation of *"0"*, *"e"*, and _exp_.
+              1. Return the string-concatenation of *"-0"*, *"e"*, and _exp_.
             1. Otherwise:
               1. Let _trailingZeroes_ be *"0"* repeated _fractionDigits_ times.
               1. Let _z_ be *"-0"*.

--- a/spec.emu
+++ b/spec.emu
@@ -281,10 +281,9 @@ location: https://github.com/tc39/proposal-amount/
               1. Let _exp_ be the unique string representation of -_fractionDigits_ in base 10 without duplicate leading zeros.
               1. Return the string-concatenation of *"-0"*, *"e"*, and _exp_.
             1. Otherwise:
+              1. If _fractionDigits_ = 0, return *"-0"*.
               1. Let _trailingZeroes_ be *"0"* repeated _fractionDigits_ times.
-              1. Let _z_ be *"-0"*.
-              1. If _fractionDigits_ = 0, return _z_.
-              1. Otherwise, return the string-concatenation of _z_, *"."* and _trailingZeroes_.
+              1. Otherwise, return the string-concatenation of *"-0"*, *"."* and _trailingZeroes_.
           1. If _v_ < 0, let _prefix_ be *"-"*, else let _prefix_ be "".
           1. If _v_ < 0, set _v_ to -_v_.
           1. Let _e_ be the smallest non-negative integer such that _v_ × 10<sup>-_e_</sup> is an integer.


### PR DESCRIPTION
I ran through some examples where we have negative fractional digits and found a couple of bugs in our `toString`. In particular, the assertion that `n ≥ 0` should have been `n ≤ 0`.

The main issue was a sign error. Looking at the problematic cases (#54)  we would convert, for instance. `"1.23e3"` into `"1.23e-3"`