### PR TITLE
Adapt `ToIntlMathematicalValue` to handle initial numeric-like text

### DIFF
--- a/intl.emu
+++ b/intl.emu
@@ -29,12 +29,12 @@
         1. Let _O_ be the *this* value.
         1. Perform ? RequireInternalSlot(_O_, [[Value]]).
         1. Let _amountUnit_ be _O_.[[Unit]].
-        1. Let _optionsUnit_ be _options_.[[unit]].
+        1. Let _optionsUnit_ be ? Get(_options_, *"unit"*).
         1. If _amountUnit_ is a String, then
           1. If _optionsUnit_ is a String, then
             1. If _amountUnit_ is not equal to _optionsUnit_, throw a *TypeError* exception.
           1. Else,
-            1. Set _options_.[[unit]] to _amountUnit_.
+            1. Call ? Set(_options_., *"unit"*, _amountUnit_, *false*).
         1. Let _numberFormat_ be ? Construct(%Intl.NumberFormat%, &laquo; _locales_, _options_ &raquo;).
         1. Return FormatNumeric(_numberFormat_, _O_.[[Value]]).
       </emu-alg>

--- a/intl.emu
+++ b/intl.emu
@@ -27,9 +27,16 @@
 
       <emu-alg>
         1. Let _O_ be the *this* value.
-        1. Perform ? RequireInternalSlot(_O_, [[Decimal128Data]]).
+        1. Perform ? RequireInternalSlot(_O_, [[Value]]).
+        1. Let _amountUnit_ be _O_.[[Unit]].
+        1. Let _optionsUnit_ be _options_.[[unit]].
+        1. If _amountUnit_ is a String, then
+          1. If _optionsUnit_ is a String, then
+            1. If _amountUnit_ is not equal to _optionsUnit_, throw a *TypeError* exception.
+          1. Else,
+            1. Set _options_.[[unit]] to _amountUnit_.
         1. Let _numberFormat_ be ? Construct(%Intl.NumberFormat%, &laquo; _locales_, _options_ &raquo;).
-        1. Return FormatNumeric(_numberFormat_, _O_.[[AmountData]]).
+        1. Return FormatNumeric(_numberFormat_, _O_.[[Value]]).
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -152,7 +159,7 @@
         </dd>
       </dl>
       <emu-alg>
-        1. <ins>If _value_ has the [[Value]] and [[FractionDigits]] internal slots, let _primValue_ be RenderAmountValueWithFractionDigits(_value_.[[Value]], _value_.[[FractionDigits]]) else</ins><del>Let</del> <ins>let</ins _primValue_ be ? ToPrimitive(_value_, ~number~).
+        1. Let _primValue_ be ? ToPrimitive(_value_, <del>~number~</del><ins>~string~</ins>).
         1. If _primValue_ is a BigInt, return ℝ(_primValue_).
         1. If _primValue_ is a String, then
           1. Let _str_ be _primValue_.
@@ -161,8 +168,10 @@
           1. If _x_ is *-0*<sub>𝔽</sub>, return ~negative-zero~.
           1. Let _str_ be Number::toString(_x_, 10).
         1. Let _text_ be StringToCodePoints(_str_).
-        1. Let _literal_ be ParseText(_text_, |StringNumericLiteral|).
-        1. If _literal_ is a List of errors, return ~not-a-number~.
+        1. Let _trimmedText_ be the longest prefix of _text_ that satisfies the syntax of a |StringNumericLiteral|, which might be _text_ itself. If there is no such prefix, return ~not-a-number~.
+        1. NOTE: The previous step is a adapted from <emu-xref href="#sec-parsefloat-string">parseFloat</emu-xref>.
+        1. Let _literal_ be ParseText(_trimmedText_, |StringNumericLiteral|).
+        1. <del>If _literal_ is a List of errors, return ~not-a-number~.</del>
         1. Let _intlMV_ be the StringIntlMV of _literal_.
         1. If _intlMV_ is a mathematical value, then
           1. Let _rounded_ be RoundMVResult(abs(_intlMV_)).

--- a/intl.emu
+++ b/intl.emu
@@ -29,12 +29,19 @@
         1. Let _O_ be the *this* value.
         1. Perform ? RequireInternalSlot(_O_, [[Value]]).
         1. Let _amountUnit_ be _O_.[[Unit]].
-        1. Let _optionsUnit_ be ? Get(_options_, *"unit"*).
+        1. If _options_ is an Object, let _optionsUnit_ be ? Get(_options_, *"unit"*) else let _optionsUnit_ be *undefined*.
         1. If _amountUnit_ is a String, then
           1. If _optionsUnit_ is a String, then
             1. If _amountUnit_ is not equal to _optionsUnit_, throw a *TypeError* exception.
-          1. Else,
-            1. Call ? Set(_options_., *"unit"*, _amountUnit_, *false*).
+          1. Else if _options_ is an Object, then
+            1. Let _propsAndValues_ be ? EnumerableOwnProperties(_options_, ~key+value~).
+            1. Let _newOptions_ be OrdinaryObjectCreate(%Object.prototype%).
+            1. For each element _propAndValue_ of _propsAndValues_, do
+              1. Let _prop_ be _propAndValue_.[[0]].
+              1. Let _value_ be _propAndValue_.[[1]].
+              1. If _prop_ is *"unit"*, set _value_ to _amountUnit_.
+              1. Call ? Set(_newOptions_, _prop_, _value_, *false*).
+            1. Set _options_ to _newOptions_.
         1. Let _numberFormat_ be ? Construct(%Intl.NumberFormat%, &laquo; _locales_, _options_ &raquo;).
         1. Return FormatNumeric(_numberFormat_, _O_.[[Value]]).
       </emu-alg>

--- a/spec.emu
+++ b/spec.emu
@@ -24,8 +24,8 @@ location: https://github.com/tc39/proposal-amount/
   <h1>The Amount Object</h1>
   <emu-intro id="sec-amount-intro">
     <h1>Introduction</h1>
-    <p>An Amount is an object that wraps mathematical value and a precision, together with a unit (e.g., mile, kilogram, EUR, JPY, USD-per-mile). One can intuitively understand an Amount as a number that, so to speak, knows its own precision and what it is measuring.</p>
-    <p>The notation for mathematical values used by Amount are <dfn id="dfn-decimal-digit-string">decimal digit string</dfn>, which are Strings that adhere to the <emu-xref href="#prod-DecimalLiteral">DecimalLiteral</emu-xref> production, excepting *"NaN"*, *"Infinity", and *"-Infinity"*.</p>
+    <p>An Amount is an object that wraps a mathematical value and a precision, together with a unit (e.g., mile, kilogram, EUR, JPY, USD-per-mile). One can intuitively understand an Amount as a number that, so to speak, knows its own precision and what it is measuring.</p>
+    <p>The notation for mathematical values used by Amount are <dfn id="dfn-decimal-digit-string">decimal digit string</dfn>, which are Strings that adhere to the <emu-xref href="#prod-DecimalLiteral">DecimalLiteral</emu-xref> production, excepting *"NaN"*, *"Infinity"*, and *"-Infinity"*.</p>
     <p>Rounding a mathematical value is an important part of this spec. When we say <dfn id="dfn-amount-rounding-mode">rounding mode</dfn> in this specification we simply refer to <emu-xref href="#table-intl-rounding-modes">ECMA-402's definition</emu-xref>.</p>
   </emu-intro>
 


### PR DESCRIPTION
Here we make `ToIntlMathematicalValue` act essentially like `parseFloat`, which allows it to handle an initial numeric string optionally followed by text like `[kg]` or `[meter-per-second]`. It's not specific to the format we have in mind for marking numeric strings with a unit.