### PR TITLE
Change serialization style

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The object prototype would provide the following methods:
   Returns a canonical exponential notation digit string together with the unit,
   surrounded by square brackets (for example, `"[1.23e+0 kilogram]"`).
   If the Amount does not have a unit,
-  the null sign `∅` (U+2205) is used in place of the unit (for example, `"[4.2e+1 ∅]"`).
+  the tilde `~` (U+007E) is used in place of the unit (for example, `"[4.2+1 ~]"`).
 
 * `toLocaleString(locale[, options])`: Return a formatted string representation
 appropriate to the locale (for example, `"1,23 kg"` in a locale that uses a comma as a fraction separator).
@@ -174,7 +174,7 @@ First, an Amount with only a value:
 let a = new Amount(123.456, { fractionDigits: 4 });
 a.value; // "1.234560e+2"
 typeof a.value; // "string"
-a.toString(); // "[1.234560e+2 ∅]"
+a.toString(); // "[1.234560e+2 ~]"
 a.toLocaleString("fr"); // "123,4560"
 ```
 

--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ The object prototype would provide the following methods:
   (such as attempting to convert a mass unit into a length unit).
 
 * `toString()`: A string representation of the Amount.
-  Returns an exponential notation digit string together with the unit,
-  surrounded by square brackets (for example, `"[1.23+0 kilogram]"`).
+  Returns a canonical exponential notation digit string together with the unit,
+  surrounded by square brackets (for example, `"[1.23e+0 kilogram]"`).
   If the Amount does not have a unit,
-  the null sign `∅` (U+2205) is used in place of the unit (for example, `"[4.2+1 ∅]"`).
+  the null sign `∅` (U+2205) is used in place of the unit (for example, `"[4.2e+1 ∅]"`).
 
 * `toLocaleString(locale[, options])`: Return a formatted string representation
 appropriate to the locale (for example, `"1,23 kg"` in a locale that uses a comma as a fraction separator).

--- a/README.md
+++ b/README.md
@@ -113,11 +113,13 @@ The object prototype would provide the following methods:
   (such as attempting to convert a mass unit into a length unit).
 
 * `toString()`: A string representation of the Amount.
-  Returns a digit string together with the unit in square brackets (e.g., `"1.23[kg]`) if the Amount does have a unit;
-  otherwise, the digit string is suffixed with empty square brackets `[]` (e.g., `"42[]"`).
+  Returns an exponential notation digit string together with the unit,
+  surrounded by square brackets (for example, `"[1.23+0 kilogram]"`).
+  If the Amount does not have a unit,
+  the null sign `∅` (U+2205) is used in place of the unit (for example, `"[4.2+1 ∅]"`).
 
 * `toLocaleString(locale[, options])`: Return a formatted string representation
-appropriate to the locale (e.g., `"1,23 kg"` in a locale that uses a comma as a fraction separator).
+appropriate to the locale (for example, `"1,23 kg"` in a locale that uses a comma as a fraction separator).
 The options are a subset of the Intl.NumberFormat constructor options.
 
 ### Unit conversion
@@ -170,19 +172,19 @@ First, an Amount with only a value:
 
 ```js
 let a = new Amount(123.456, { fractionDigits: 4 });
-a.value; // "123.4560"
+a.value; // "1.234560e+2"
 typeof a.value; // "string"
-a.toString(); // "123.4560[]"
+a.toString(); // "[1.234560e+2 ∅]"
 a.toLocaleString("fr"); // "123,4560"
 ```
 
 Here's an example with units:
 
 ```js
-let a = new Amount(42.7, { unit: "kg" });
+let a = new Amount(42.7, { unit: "kilogram" });
 a.value; // 42.7
 typeof a.value; // "number"
-a.toString(); // "42.7[kg]"
+a.toString(); // "[4.27e+1 kilogram]"
 a.toLocaleString("fr"); // "42,7 kg"
 ```
 
@@ -270,14 +272,14 @@ If the given precision is less than that of the input value, rounding will occur
 
 ```js
 let a = new Amount("123.456", { significantDigits: 5 });
-a.value; // "123.46"
+a.value; // "1.2346e+2"
 ```
 
 By default, we use the round-ties-to-even rounding mode, which is used by IEEE 754 standard, and thus by Number and [Decimal](https://github.com/tc39/proposal-decimal). One can specify a rounding mode:
 
 ```js
 let b = new Amount("123.456", { significantDigits: 5, roundingMode: "truncate" });
-b.value; // "123.45"
+b.value; // "1.2345e+2"
 ```
 
 ### Units (including currency)
@@ -285,7 +287,7 @@ b.value; // "123.45"
 A core piece of functionality for the proposal is to support units (`mile`, `kilogram`, etc.) as well as currency (`EUR`, `USD`, etc.). An Amount need not have a unit/currency, and if it does, it has one or the other (not both). Example:
 
 ```js
-let a = new Amount(123.456, { unit: "kg" }); // 123.456 kilograms
+let a = new Amount(123.456, { unit: "kilogram" }); // 123.456 kilograms
 let b = new Amount("42.55", { unit: "EUR" }); // 42.55 Euros
 ```
 

--- a/README.md
+++ b/README.md
@@ -113,8 +113,9 @@ The object prototype would provide the following methods:
   (such as attempting to convert a mass unit into a length unit).
 
 * `toString()`: A string representation of the Amount.
-  Returns a digit string together with the unit in square brackets (e.g., `"1.23[kilogram]`) if the Amount does have a unit;
-  otherwise, the digit string is suffixed with empty square brackets `[]` (e.g., `"42[]"`).
+  Returns a digit string together with the unit, surrounded by square brackets (for example, `"[1.23+e0 kilogram]"`).
+  If the Amount does not have a unit,
+  the tilde `~` (U+007E) is used in place of the unit (for example, `"[4.2+e1 ~]"`).
 
 * `toLocaleString(locale[, options])`: Return a formatted string representation
 appropriate to the locale (for example, `"1,23 kg"` in a locale that uses a comma as a fraction separator).
@@ -172,7 +173,7 @@ First, an Amount with only a value:
 let a = new Amount(123.456, { fractionDigits: 4 });
 a.value; // "1.234560e+2"
 typeof a.value; // "string"
-a.toString(); // "1.234560e+2[]"
+a.toString(); // "[1.234560e+2 ~]"
 a.toLocaleString("fr"); // "123,4560"
 ```
 
@@ -182,7 +183,7 @@ Here's an example with units:
 let a = new Amount(42.7, { unit: "kilogram" });
 a.value; // 42.7
 typeof a.value; // "number"
-a.toString(); // "4.27e+1[kilogram]"
+a.toString(); // "[4.27e+1 kilogram]"
 a.toLocaleString("fr"); // "42,7 kg"
 ```
 

--- a/spec.emu
+++ b/spec.emu
@@ -359,8 +359,9 @@ location: https://github.com/tc39/proposal-amount/
       1. Else,
         1. Assert: _v_ is a BigInt.
         1. Let _valueStr_ be BigInt::toString(_v_, 10).
-      1. If _u_ is *undefined*, return the string-concatenation of _valueStr_ and *"[]"*.
-      1. Return the string-concatenation of _valueStr_, *"["*, _u_, and *"]"*.
+      1. TODO: Normalize _valueStr_ to use exponential notation.
+      1. If _u_ is *undefined*, return the string-concatenation of *"["*, _valueStr_, and *" ∅]"*.
+      1. Return the string-concatenation of *"["*, _valueStr_, *" "*, _u_, and *"]"*.
     </emu-alg>
   </emu-clause>
 

--- a/spec.emu
+++ b/spec.emu
@@ -360,7 +360,7 @@ location: https://github.com/tc39/proposal-amount/
         1. Assert: _v_ is a BigInt.
         1. Let _valueStr_ be BigInt::toString(_v_, 10).
       1. TODO: Normalize _valueStr_ to use exponential notation.
-      1. If _u_ is *undefined*, return the string-concatenation of *"["*, _valueStr_, and *" ∅]"*.
+      1. If _u_ is *undefined*, return the string-concatenation of *"["*, _valueStr_, and *" ~]"*.
       1. Return the string-concatenation of *"["*, _valueStr_, *" "*, _u_, and *"]"*.
     </emu-alg>
   </emu-clause>

--- a/spec.emu
+++ b/spec.emu
@@ -410,8 +410,8 @@ location: https://github.com/tc39/proposal-amount/
         1. Let _digits_ be BigInt::toString(_v_, 10).
         1. Let _intlMV_ be ! ToIntlMathematicalValue(_digits_).
         1. Let _valueStr_ be RenderInExponentialNotation(_intlMV_.[[Value]], _intlMV_.[[StringDigitCount]]).
-      1. If _u_ is *undefined*, return the string-concatenation of _valueStr_ and *"[]"*.
-      1. Return the string-concatenation of _valueStr_, *"["*, _u_, and *"]"*.
+      1. If _u_ is *undefined*, return the string-concatenation of *"["*, _valueStr_, and *" ~]"*.
+      1. Return the string-concatenation of *"["*, _valueStr_, *" "*, _u_, and *"]"*.
     </emu-alg>
   </emu-clause>
 


### PR DESCRIPTION
Fixes #97. Introduces a new serialization style for Amount.prototype.toString: the value and unit are surrounded by square brackets and separated by a single space (for example, "[1.23e+0 kilogram]"); for Amounts with no unit, a tilde "~" (U+007E) is used in place of the unit (for example, "[4.2e+1 ~]").

This PR originally included a change applying exponential-notation rendering of string values; that is now in #104.

CC @gibson042, @ljharb, @sffc.