### PR TITLE
Use exponential notation for rendering Amount values

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,8 @@ The object prototype would provide the following methods:
   (such as attempting to convert a mass unit into a length unit).
 
 * `toString()`: A string representation of the Amount.
-  Returns a canonical exponential notation digit string together with the unit,
-  surrounded by square brackets (for example, `"[1.23e+0 kilogram]"`).
-  If the Amount does not have a unit,
-  the null sign `∅` (U+2205) is used in place of the unit (for example, `"[4.2e+1 ∅]"`).
+  Returns a digit string together with the unit in square brackets (e.g., `"1.23[kg]`) if the Amount does have a unit;
+  otherwise, the digit string is suffixed with empty square brackets `[]` (e.g., `"42[]"`).
 
 * `toLocaleString(locale[, options])`: Return a formatted string representation
 appropriate to the locale (for example, `"1,23 kg"` in a locale that uses a comma as a fraction separator).

--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ The object prototype would provide the following methods:
   (such as attempting to convert a mass unit into a length unit).
 
 * `toString()`: A string representation of the Amount.
-  Returns an exponential notation digit string together with the unit,
-  surrounded by square brackets (for example, `"[1.23+0 kilogram]"`).
+  Returns a canonical exponential notation digit string together with the unit,
+  surrounded by square brackets (for example, `"[1.23e+0 kilogram]"`).
   If the Amount does not have a unit,
-  the null sign `∅` (U+2205) is used in place of the unit (for example, `"[4.2+1 ∅]"`).
+  the null sign `∅` (U+2205) is used in place of the unit (for example, `"[4.2e+1 ∅]"`).
 
 * `toLocaleString(locale[, options])`: Return a formatted string representation
 appropriate to the locale (for example, `"1,23 kg"` in a locale that uses a comma as a fraction separator).

--- a/README.md
+++ b/README.md
@@ -113,11 +113,13 @@ The object prototype would provide the following methods:
   (such as attempting to convert a mass unit into a length unit).
 
 * `toString()`: A string representation of the Amount.
-  Returns a digit string together with the unit in square brackets (e.g., `"1.23[kg]`) if the Amount does have a unit;
-  otherwise, the digit string is suffixed with empty square brackets `[]` (e.g., `"42[]"`).
+  Returns an exponential notation digit string together with the unit,
+  surrounded by square brackets (for example, `"[1.23+0 kilogram]"`).
+  If the Amount does not have a unit,
+  the null sign `∅` (U+2205) is used in place of the unit (for example, `"[4.2+1 ∅]"`).
 
 * `toLocaleString(locale[, options])`: Return a formatted string representation
-appropriate to the locale (e.g., `"1,23 kg"` in a locale that uses a comma as a fraction separator).
+appropriate to the locale (for example, `"1,23 kg"` in a locale that uses a comma as a fraction separator).
 The options are a subset of the Intl.NumberFormat constructor options.
 
 ### Unit conversion
@@ -170,19 +172,19 @@ First, an Amount with only a value:
 
 ```js
 let a = new Amount(123.456, { fractionDigits: 4 });
-a.value; // "123.4560"
+a.value; // "1.234560e+2"
 typeof a.value; // "string"
-a.toString(); // "123.4560[]"
+a.toString(); // "[1.234560e+2 ∅]"
 a.toLocaleString("fr"); // "123,4560"
 ```
 
 Here's an example with units:
 
 ```js
-let a = new Amount(42.7, { unit: "kg" });
+let a = new Amount(42.7, { unit: "kilogram" });
 a.value; // 42.7
 typeof a.value; // "number"
-a.toString(); // "42.7[kg]"
+a.toString(); // "[4.27e+1 kilogram]"
 a.toLocaleString("fr"); // "42,7 kg"
 ```
 
@@ -270,14 +272,14 @@ If the given precision is less than that of the input value, rounding will occur
 
 ```js
 let a = new Amount("123.456", { significantDigits: 5 });
-a.value; // "123.46"
+a.value; // "1.2346e+2"
 ```
 
 By default, we use the round-ties-to-even rounding mode, which is used by IEEE 754 standard, and thus by Number and [Decimal](https://github.com/tc39/proposal-decimal). One can specify a rounding mode:
 
 ```js
 let b = new Amount("123.456", { significantDigits: 5, roundingMode: "truncate" });
-b.value; // "123.45"
+b.value; // "1.2345e+2"
 ```
 
 ### Units (including currency)
@@ -285,7 +287,7 @@ b.value; // "123.45"
 A core piece of functionality for the proposal is to support units (`mile`, `kilogram`, etc.) as well as currency (`EUR`, `USD`, etc.). An Amount need not have a unit/currency, and if it does, it has one or the other (not both). Example:
 
 ```js
-let a = new Amount(123.456, { unit: "kg" }); // 123.456 kilograms
+let a = new Amount(123.456, { unit: "kilogram" }); // 123.456 kilograms
 let b = new Amount("42.55", { unit: "EUR" }); // 42.55 Euros
 ```
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ First, an Amount with only a value:
 let a = new Amount(123.456, { fractionDigits: 4 });
 a.value; // "1.234560e+2"
 typeof a.value; // "string"
-a.toString(); // "[1.234560e+2 ∅]"
+a.toString(); // "1.234560e+2[]"
 a.toLocaleString("fr"); // "123,4560"
 ```
 
@@ -182,7 +182,7 @@ Here's an example with units:
 let a = new Amount(42.7, { unit: "kilogram" });
 a.value; // 42.7
 typeof a.value; // "number"
-a.toString(); // "[4.27e+1 kilogram]"
+a.toString(); // "4.27e+1[kilogram]"
 a.toLocaleString("fr"); // "42,7 kg"
 ```
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The object prototype would provide the following methods:
   (such as attempting to convert a mass unit into a length unit).
 
 * `toString()`: A string representation of the Amount.
-  Returns a digit string together with the unit in square brackets (e.g., `"1.23[kg]`) if the Amount does have a unit;
+  Returns a digit string together with the unit in square brackets (e.g., `"1.23[kilogram]`) if the Amount does have a unit;
   otherwise, the digit string is suffixed with empty square brackets `[]` (e.g., `"42[]"`).
 
 * `toLocaleString(locale[, options])`: Return a formatted string representation

--- a/spec.emu
+++ b/spec.emu
@@ -359,8 +359,9 @@ location: https://github.com/tc39/proposal-amount/
       1. Else,
         1. Assert: _v_ is a BigInt.
         1. Let _valueStr_ be BigInt::toString(_v_, 10).
-      1. If _u_ is *undefined*, return the string-concatenation of _valueStr_ and *"[]"*.
-      1. Return the string-concatenation of _valueStr_, *"["*, _u_, and *"]"*.
+      1. TODO: Normalize _valueStr_ to use exponential notation.
+      1. If _u_ is *undefined*, return the string-concatenation of *"["*, _valueStr_, and *" ∅]"*.
+      1. Return the string-concatenation of *"["*, _valueStr_, *" "*, _u_, and *"]"*.
     </emu-alg>
   </emu-clause>
 

--- a/spec.emu
+++ b/spec.emu
@@ -426,8 +426,8 @@ location: https://github.com/tc39/proposal-amount/
       1. Else,
         1. Assert: _v_ is a BigInt.
         1. Let _valueStr_ be RenderBigIntInExponentialNotation(_v_).
-      1. If _u_ is *undefined*, return the string-concatenation of *"["*, _valueStr_, and *" ∅]"*.
-      1. Return the string-concatenation of *"["*, _valueStr_, *" "*, _u_, and *"]"*.
+      1. If _u_ is *undefined*, return the string-concatenation of _valueStr_ and *"[]"*.
+      1. Return the string-concatenation of _valueStr_, *"["*, _u_, and *"]"*.
     </emu-alg>
   </emu-clause>
 

--- a/spec.emu
+++ b/spec.emu
@@ -208,8 +208,8 @@ location: https://github.com/tc39/proposal-amount/
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-amount-renderstringinexponentialnotation" type="abstract operation">
-        <h1>RenderStringInExponentialNotation (
+      <emu-clause id="sec-amount-renderdigitstringinexponentialnotation" type="abstract operation">
+        <h1>RenderDigitStringInExponentialNotation (
           _v_: a String
         ): a String
         </h1>
@@ -366,7 +366,7 @@ location: https://github.com/tc39/proposal-amount/
           1. Let _formatter_ be CreateFormatterObject(_roundingMode_, _fractionDigits_, _fractionDigits_, _significantDigits_, _significantDigits_, *undefined*).
           1. Let _intlMV_ be ! ToIntlMathematicalValue(_x_).
           1. Let _formatted_ be FormatNumericToString(_formatter_, _intlMV_.[[Value]], _intlMV_.[[StringDigitCount]]).
-          1. Let _value_ be RenderStringInExponentialNotation(_formatted_.[[FormattedString]]).
+          1. Let _value_ be RenderDigitStringInExponentialNotation(_formatted_.[[FormattedString]]).
         1. Let _O_ be OrdinaryObjectCreate(%Amount.prototype%, « [[AmountValue]], [[Unit]] »).
         1. Set _O_.[[AmountValue]] to _value_.
         1. Set _O_.[[Unit]] to _unit_.
@@ -473,7 +473,7 @@ location: https://github.com/tc39/proposal-amount/
       1. Let _formatter_ be CreateFormatterObject(_roundingMode_, _minFractionDigits_, _maxFractionDigits_, _minSignificantDigits_, _maxSignificantDigits_, _roundingPriority_).
       1. Let _formatted_ be FormatNumericToString(_formatter_, ℝ(_convertedValue_), 0).
       1. Let _result_ be OrdinaryObjectCreate(%Amount.prototype%, « [[AmountValue]], [[Unit]] »).
-      1. Set _result_.[[AmountValue]] to RenderStringInExponentialNotation(_formatted_.[[FormattedString]]).
+      1. Set _result_.[[AmountValue]] to RenderDigitStringInExponentialNotation(_formatted_.[[FormattedString]]).
       1. Set _result_.[[Unit]] to _targetUnit_.
       1. Return _result_.
     </emu-alg>

--- a/spec.emu
+++ b/spec.emu
@@ -218,13 +218,12 @@ location: https://github.com/tc39/proposal-amount/
           <dd>It returns _v_ rendered in canonical exponential notation: an optional minus sign, a mantissa with one non-zero integer digit (or *"0"*), an optional fractional part, *"e"*, an explicit sign, and an unpadded base-10 exponent. The number of significant digits in the result equals the number of significant digits in _v_. If _v_ is *"NaN"*, *"Infinity"*, or *"-Infinity"*, it is returned unchanged.</dd>
         </dl>
         <emu-alg>
-          1. If _v_ is *"NaN"*, *"Infinity"*, or *"-Infinity"*, return _v_.
-          1. Let _text_ be StringToCodePoints(_v_).
-          1. Let _literal_ be ParseText(_text_, |StrDecimalLiteral|).
-          1. Assert: _literal_ is not a List of errors.
-          1. Let _stringData_ be StringIntlMV of _literal_.
-          1. Let _value_ be _stringData_[0].
-          1. Let _digitCount_ be _stringData_[1].
+          1. Let _intlMV_ be ! ToIntlMathematicalValue(_v_).
+          1. Let _value_ be _intlMV_.[[Value]].
+          1. If _value_ is ~not-a-number~, return *"NaN"*.
+          1. If _value_ is ~positive-infinity~, return *"Infinity"*.
+          1. If _value_ is ~negative-infinity~, return *"-Infinity"*.
+          1. Let _digitCount_ be _intlMV_.[[StringDigitCount]].
           1. Let _sign_ be the empty String.
           1. If _value_ is ~negative-zero~, then
             1. Set _sign_ to *"-"*.

--- a/spec.emu
+++ b/spec.emu
@@ -241,9 +241,6 @@ location: https://github.com/tc39/proposal-amount/
           1. Let _expStr_ be the unique base-10 String representation of abs(_exponent_) with no leading zeros.
           1. Return the string-concatenation of _sign_, _mantissaStr_, *"e"*, _expSign_, and _expStr_.
         </emu-alg>
-        <emu-note>
-          <p>The mantissa is always in the half-open interval [1, 10), so it has exactly one integer digit. Configuring the formatter with <emu-eqn>_digitCount_ - 1</emu-eqn> minimum and maximum fraction digits yields exactly _digitCount_ significant digits in the formatted mantissa, preserving the precision implied by the input. Using fraction digits (rather than significant digits) sidesteps the upper bound of 21 on <emu-xref href="#sec-amount-createformatterobject">CreateFormatterObject</emu-xref>'s significant-digit slots.</p>
-        </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-amount-renderbigintinexponentialnotation" type="abstract operation">

--- a/spec.emu
+++ b/spec.emu
@@ -208,6 +208,77 @@ location: https://github.com/tc39/proposal-amount/
         </emu-note>
       </emu-clause>
 
+      <emu-clause id="sec-amount-renderstringinexponentialnotation" type="abstract operation">
+        <h1>RenderStringInExponentialNotation (
+          _v_: a String
+        ): a String
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It returns _v_ rendered in canonical exponential notation: an optional minus sign, a mantissa with one non-zero integer digit (or *"0"*), an optional fractional part, *"e"*, an explicit sign, and an unpadded base-10 exponent. The number of significant digits in the result equals the number of significant digits in _v_. If _v_ is *"NaN"*, *"Infinity"*, or *"-Infinity"*, it is returned unchanged.</dd>
+        </dl>
+        <emu-alg>
+          1. If _v_ is *"NaN"*, *"Infinity"*, or *"-Infinity"*, return _v_.
+          1. Let _text_ be StringToCodePoints(_v_).
+          1. Let _literal_ be ParseText(_text_, |StrDecimalLiteral|).
+          1. Assert: _literal_ is not a List of errors.
+          1. Let _stringData_ be StringIntlMV of _literal_.
+          1. Let _value_ be _stringData_[0].
+          1. Let _digitCount_ be _stringData_[1].
+          1. Let _sign_ be the empty String.
+          1. If _value_ is ~negative-zero~, then
+            1. Set _sign_ to *"-"*.
+            1. Set _value_ to 0.
+          1. Else if _value_ &lt; 0, then
+            1. Set _sign_ to *"-"*.
+            1. Set _value_ to -_value_.
+          1. If _value_ = 0, let _exponent_ be 0; else, let _exponent_ be the unique integer such that 10<sup>_exponent_</sup> ≤ _value_ &lt; 10<sup>_exponent_ + 1</sup>.
+          1. Let _mantissa_ be _value_ × 10<sup>-_exponent_</sup>.
+          1. Let _fracDigits_ be _digitCount_ - 1.
+          1. Let _formatter_ be CreateFormatterObject(*"halfEven"*, _fracDigits_, _fracDigits_, *undefined*, *undefined*, *undefined*).
+          1. Let _formatted_ be FormatNumericToString(_formatter_, _mantissa_, _digitCount_).
+          1. Let _mantissaStr_ be _formatted_.[[FormattedString]].
+          1. If _exponent_ ≥ 0, let _expSign_ be *"+"*; else let _expSign_ be *"-"*.
+          1. Let _expStr_ be the unique base-10 String representation of abs(_exponent_) with no leading zeros.
+          1. Return the string-concatenation of _sign_, _mantissaStr_, *"e"*, _expSign_, and _expStr_.
+        </emu-alg>
+        <emu-note>
+          <p>The mantissa is always in the half-open interval [1, 10), so it has exactly one integer digit. Configuring the formatter with <emu-eqn>_digitCount_ - 1</emu-eqn> minimum and maximum fraction digits yields exactly _digitCount_ significant digits in the formatted mantissa, preserving the precision implied by the input. Using fraction digits (rather than significant digits) sidesteps the upper bound of 21 on <emu-xref href="#sec-amount-createformatterobject">CreateFormatterObject</emu-xref>'s significant-digit slots.</p>
+        </emu-note>
+      </emu-clause>
+
+      <emu-clause id="sec-amount-renderbigintinexponentialnotation" type="abstract operation">
+        <h1>RenderBigIntInExponentialNotation (
+          _b_: a BigInt
+        ): a String
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It returns _b_ rendered in canonical exponential notation: an optional minus sign, a single non-zero integer digit (or *"0"* when _b_ is *0*<sub>ℤ</sub>), optionally followed by *"."* and additional fractional digits when more precision is required, *"e+"*, and a base-10 exponent without leading zeros. Trailing zeros of _b_ are absorbed into the exponent.</dd>
+        </dl>
+        <emu-alg>
+          1. If _b_ = *0*<sub>ℤ</sub>, return *"0e+0"*.
+          1. Let _sign_ be the empty String.
+          1. If _b_ &lt; *0*<sub>ℤ</sub>, then
+            1. Set _sign_ to *"-"*.
+            1. Set _b_ to -_b_.
+          1. Let _digits_ be BigInt::toString(_b_, 10).
+          1. Let _len_ be the length of _digits_.
+          1. Let _trailingZeros_ be the largest non-negative integer _k_ such that the last _k_ code units of _digits_ are all 0x0030 (DIGIT ZERO).
+          1. Let _significantLen_ be _len_ - _trailingZeros_.
+          1. Let _significantDigits_ be the substring of _digits_ from 0 to _significantLen_.
+          1. If _significantLen_ = 1, then
+            1. Let _mantissaStr_ be _significantDigits_.
+          1. Else,
+            1. Let _intDigit_ be the substring of _significantDigits_ from 0 to 1.
+            1. Let _fracDigits_ be the substring of _significantDigits_ from 1 to _significantLen_.
+            1. Let _mantissaStr_ be the string-concatenation of _intDigit_, *"."*, and _fracDigits_.
+          1. Let _exponent_ be _len_ - 1.
+          1. Let _expStr_ be the unique base-10 String representation of _exponent_ with no leading zeros.
+          1. Return the string-concatenation of _sign_, _mantissaStr_, *"e+"*, and _expStr_.
+        </emu-alg>
+      </emu-clause>
+
       <emu-clause id="sec-amount-getunitconversionfactor" type="abstract operation">
         <h1>GetUnitConversionFactor (
           _unit_: a String
@@ -299,14 +370,14 @@ location: https://github.com/tc39/proposal-amount/
           1. Let _formatter_ be CreateFormatterObject(_roundingMode_, _fractionDigits_, _fractionDigits_, _significantDigits_, _significantDigits_, *undefined*).
           1. Let _intlMV_ be ! ToIntlMathematicalValue(_x_).
           1. Let _formatted_ be FormatNumericToString(_formatter_, _intlMV_.[[Value]], _intlMV_.[[StringDigitCount]]).
-          1. Let _value_ be _formatted_.[[FormattedString]].
+          1. Let _value_ be RenderStringInExponentialNotation(_formatted_.[[FormattedString]]).
         1. Let _O_ be OrdinaryObjectCreate(%Amount.prototype%, « [[AmountValue]], [[Unit]] »).
         1. Set _O_.[[AmountValue]] to _value_.
         1. Set _O_.[[Unit]] to _unit_.
         1. Return _O_.
       </emu-alg>
       <emu-note>
-        <p>When no precision options are given, Number and BigInt arguments are stored directly in [[AmountValue]], preserving the original type. String arguments are normalized to StrDecimalLiteral form. When precision options are specified, [[AmountValue]] always holds a String.</p>
+        <p>When no precision options are given, Number and BigInt arguments are stored directly in [[AmountValue]], preserving the original type. String arguments and values resulting from precision options are stored as a String in canonical exponential notation, preserving the precision implied by the input.</p>
       </emu-note>
       <emu-note type="editor">
 	<p>
@@ -355,11 +426,10 @@ location: https://github.com/tc39/proposal-amount/
       1. If _v_ is a String, then
         1. Let _valueStr_ be _v_.
       1. Else if _v_ is a Number, then
-        1. Let _valueStr_ be Number::toString(_v_, 10).
+        1. Let _valueStr_ be ! Call(%Number.prototype.toExponential%, _v_, « »).
       1. Else,
         1. Assert: _v_ is a BigInt.
-        1. Let _valueStr_ be BigInt::toString(_v_, 10).
-      1. TODO: Normalize _valueStr_ to use exponential notation.
+        1. Let _valueStr_ be RenderBigIntInExponentialNotation(_v_).
       1. If _u_ is *undefined*, return the string-concatenation of *"["*, _valueStr_, and *" ∅]"*.
       1. Return the string-concatenation of *"["*, _valueStr_, *" "*, _u_, and *"]"*.
     </emu-alg>
@@ -407,7 +477,7 @@ location: https://github.com/tc39/proposal-amount/
       1. Let _formatter_ be CreateFormatterObject(_roundingMode_, _minFractionDigits_, _maxFractionDigits_, _minSignificantDigits_, _maxSignificantDigits_, _roundingPriority_).
       1. Let _formatted_ be FormatNumericToString(_formatter_, ℝ(_convertedValue_), 0).
       1. Let _result_ be OrdinaryObjectCreate(%Amount.prototype%, « [[AmountValue]], [[Unit]] »).
-      1. Set _result_.[[AmountValue]] to _formatted_.[[FormattedString]].
+      1. Set _result_.[[AmountValue]] to RenderStringInExponentialNotation(_formatted_.[[FormattedString]]).
       1. Set _result_.[[Unit]] to _targetUnit_.
       1. Return _result_.
     </emu-alg>

--- a/spec.emu
+++ b/spec.emu
@@ -196,6 +196,77 @@ location: https://github.com/tc39/proposal-amount/
         </emu-note>
       </emu-clause>
 
+      <emu-clause id="sec-amount-renderstringinexponentialnotation" type="abstract operation">
+        <h1>RenderStringInExponentialNotation (
+          _v_: a String
+        ): a String
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It returns _v_ rendered in canonical exponential notation: an optional minus sign, a mantissa with one non-zero integer digit (or *"0"*), an optional fractional part, *"e"*, an explicit sign, and an unpadded base-10 exponent. The number of significant digits in the result equals the number of significant digits in _v_. If _v_ is *"NaN"*, *"Infinity"*, or *"-Infinity"*, it is returned unchanged.</dd>
+        </dl>
+        <emu-alg>
+          1. If _v_ is *"NaN"*, *"Infinity"*, or *"-Infinity"*, return _v_.
+          1. Let _text_ be StringToCodePoints(_v_).
+          1. Let _literal_ be ParseText(_text_, |StrDecimalLiteral|).
+          1. Assert: _literal_ is not a List of errors.
+          1. Let _stringData_ be StringIntlMV of _literal_.
+          1. Let _value_ be _stringData_[0].
+          1. Let _digitCount_ be _stringData_[1].
+          1. Let _sign_ be the empty String.
+          1. If _value_ is ~negative-zero~, then
+            1. Set _sign_ to *"-"*.
+            1. Set _value_ to 0.
+          1. Else if _value_ &lt; 0, then
+            1. Set _sign_ to *"-"*.
+            1. Set _value_ to -_value_.
+          1. If _value_ = 0, let _exponent_ be 0; else, let _exponent_ be the unique integer such that 10<sup>_exponent_</sup> ≤ _value_ &lt; 10<sup>_exponent_ + 1</sup>.
+          1. Let _mantissa_ be _value_ × 10<sup>-_exponent_</sup>.
+          1. Let _fracDigits_ be _digitCount_ - 1.
+          1. Let _formatter_ be CreateFormatterObject(*"halfEven"*, _fracDigits_, _fracDigits_, *undefined*, *undefined*, *undefined*).
+          1. Let _formatted_ be FormatNumericToString(_formatter_, _mantissa_, _digitCount_).
+          1. Let _mantissaStr_ be _formatted_.[[FormattedString]].
+          1. If _exponent_ ≥ 0, let _expSign_ be *"+"*; else let _expSign_ be *"-"*.
+          1. Let _expStr_ be the unique base-10 String representation of abs(_exponent_) with no leading zeros.
+          1. Return the string-concatenation of _sign_, _mantissaStr_, *"e"*, _expSign_, and _expStr_.
+        </emu-alg>
+        <emu-note>
+          <p>The mantissa is always in the half-open interval [1, 10), so it has exactly one integer digit. Configuring the formatter with <emu-eqn>_digitCount_ - 1</emu-eqn> minimum and maximum fraction digits yields exactly _digitCount_ significant digits in the formatted mantissa, preserving the precision implied by the input. Using fraction digits (rather than significant digits) sidesteps the upper bound of 21 on <emu-xref href="#sec-amount-createformatterobject">CreateFormatterObject</emu-xref>'s significant-digit slots.</p>
+        </emu-note>
+      </emu-clause>
+
+      <emu-clause id="sec-amount-renderbigintinexponentialnotation" type="abstract operation">
+        <h1>RenderBigIntInExponentialNotation (
+          _b_: a BigInt
+        ): a String
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd>It returns _b_ rendered in canonical exponential notation: an optional minus sign, a single non-zero integer digit (or *"0"* when _b_ is *0*<sub>ℤ</sub>), optionally followed by *"."* and additional fractional digits when more precision is required, *"e+"*, and a base-10 exponent without leading zeros. Trailing zeros of _b_ are absorbed into the exponent.</dd>
+        </dl>
+        <emu-alg>
+          1. If _b_ = *0*<sub>ℤ</sub>, return *"0e+0"*.
+          1. Let _sign_ be the empty String.
+          1. If _b_ &lt; *0*<sub>ℤ</sub>, then
+            1. Set _sign_ to *"-"*.
+            1. Set _b_ to -_b_.
+          1. Let _digits_ be BigInt::toString(_b_, 10).
+          1. Let _len_ be the length of _digits_.
+          1. Let _trailingZeros_ be the largest non-negative integer _k_ such that the last _k_ code units of _digits_ are all 0x0030 (DIGIT ZERO).
+          1. Let _significantLen_ be _len_ - _trailingZeros_.
+          1. Let _significantDigits_ be the substring of _digits_ from 0 to _significantLen_.
+          1. If _significantLen_ = 1, then
+            1. Let _mantissaStr_ be _significantDigits_.
+          1. Else,
+            1. Let _intDigit_ be the substring of _significantDigits_ from 0 to 1.
+            1. Let _fracDigits_ be the substring of _significantDigits_ from 1 to _significantLen_.
+            1. Let _mantissaStr_ be the string-concatenation of _intDigit_, *"."*, and _fracDigits_.
+          1. Let _exponent_ be _len_ - 1.
+          1. Let _expStr_ be the unique base-10 String representation of _exponent_ with no leading zeros.
+          1. Return the string-concatenation of _sign_, _mantissaStr_, *"e+"*, and _expStr_.
+        </emu-alg>
+      </emu-clause>
+
       <emu-clause id="sec-amount-getunitconversionfactor" type="abstract operation">
         <h1>GetUnitConversionFactor (
           _unit_: a String
@@ -287,14 +358,14 @@ location: https://github.com/tc39/proposal-amount/
           1. Let _formatter_ be CreateFormatterObject(_roundingMode_, _fractionDigits_, _fractionDigits_, _significantDigits_, _significantDigits_, *undefined*).
           1. Let _intlMV_ be ! ToIntlMathematicalValue(_x_).
           1. Let _formatted_ be FormatNumericToString(_formatter_, _intlMV_.[[Value]], _intlMV_.[[StringDigitCount]]).
-          1. Let _value_ be _formatted_.[[FormattedString]].
+          1. Let _value_ be RenderStringInExponentialNotation(_formatted_.[[FormattedString]]).
         1. Let _O_ be OrdinaryObjectCreate(%Amount.prototype%, « [[AmountValue]], [[Unit]] »).
         1. Set _O_.[[AmountValue]] to _value_.
         1. Set _O_.[[Unit]] to _unit_.
         1. Return _O_.
       </emu-alg>
       <emu-note>
-        <p>When no precision options are given, Number and BigInt arguments are stored directly in [[AmountValue]], preserving the original type. String arguments are normalized to StrDecimalLiteral form. When precision options are specified, [[AmountValue]] always holds a String.</p>
+        <p>When no precision options are given, Number and BigInt arguments are stored directly in [[AmountValue]], preserving the original type. String arguments and values resulting from precision options are stored as a String in canonical exponential notation, preserving the precision implied by the input.</p>
       </emu-note>
       <emu-note type="editor">
 	<p>
@@ -343,11 +414,10 @@ location: https://github.com/tc39/proposal-amount/
       1. If _v_ is a String, then
         1. Let _valueStr_ be _v_.
       1. Else if _v_ is a Number, then
-        1. Let _valueStr_ be Number::toString(_v_, 10).
+        1. Let _valueStr_ be ! Call(%Number.prototype.toExponential%, _v_, « »).
       1. Else,
         1. Assert: _v_ is a BigInt.
-        1. Let _valueStr_ be BigInt::toString(_v_, 10).
-      1. TODO: Normalize _valueStr_ to use exponential notation.
+        1. Let _valueStr_ be RenderBigIntInExponentialNotation(_v_).
       1. If _u_ is *undefined*, return the string-concatenation of *"["*, _valueStr_, and *" ∅]"*.
       1. Return the string-concatenation of *"["*, _valueStr_, *" "*, _u_, and *"]"*.
     </emu-alg>
@@ -393,7 +463,7 @@ location: https://github.com/tc39/proposal-amount/
       1. If _convertedValue_ is finite and (_fractionDigits_ is not *undefined* or _significantDigits_ is not *undefined*), then
         1. Let _formatter_ be CreateFormatterObject(_roundingMode_, _fractionDigits_, _fractionDigits_, _significantDigits_, _significantDigits_, *undefined*).
         1. Let _formatted_ be FormatNumericToString(_formatter_, ℝ(_convertedValue_), 0).
-        1. Set _result_.[[AmountValue]] to _formatted_.[[FormattedString]].
+        1. Set _result_.[[AmountValue]] to RenderStringInExponentialNotation(_formatted_.[[FormattedString]]).
       1. Else,
         1. Set _result_.[[AmountValue]] to _convertedValue_.
       1. Set _result_.[[Unit]] to _targetUnit_.

--- a/spec.emu
+++ b/spec.emu
@@ -229,9 +229,6 @@ location: https://github.com/tc39/proposal-amount/
           1. Let _expStr_ be the unique base-10 String representation of abs(_exponent_) with no leading zeros.
           1. Return the string-concatenation of _sign_, _mantissaStr_, *"e"*, _expSign_, and _expStr_.
         </emu-alg>
-        <emu-note>
-          <p>The mantissa is always in the half-open interval [1, 10), so it has exactly one integer digit. Configuring the formatter with <emu-eqn>_digitCount_ - 1</emu-eqn> minimum and maximum fraction digits yields exactly _digitCount_ significant digits in the formatted mantissa, preserving the precision implied by the input. Using fraction digits (rather than significant digits) sidesteps the upper bound of 21 on <emu-xref href="#sec-amount-createformatterobject">CreateFormatterObject</emu-xref>'s significant-digit slots.</p>
-        </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-amount-renderbigintinexponentialnotation" type="abstract operation">

--- a/spec.emu
+++ b/spec.emu
@@ -418,7 +418,15 @@ location: https://github.com/tc39/proposal-amount/
       1. If _v_ is a String, then
         1. Let _valueStr_ be _v_.
       1. Else if _v_ is a Number, then
-        1. Let _valueStr_ be ! Call(%Number.prototype.toExponential%, _v_, « »).
+        1. If _v_ is *NaN*, then
+          1. Let _valueStr_ be *"NaN"*.
+        1. Else if _v_ is *+&infin;*<sub>𝔽</sub>, then
+          1. Let _valueStr_ be *"Infinity"*.
+        1. Else if _v_ is *-&infin;*<sub>𝔽</sub>, then
+          1. Let _valueStr_ be *"-Infinity"*.
+        1. Else,
+          1. Let _decimalStr_ be Number::toString(_v_, 10).
+          1. Let _valueStr_ be RenderDigitStringInExponentialNotation(_decimalStr_).
       1. Else,
         1. Assert: _v_ is a BigInt.
         1. Let _valueStr_ be RenderBigIntInExponentialNotation(_v_).

--- a/spec.emu
+++ b/spec.emu
@@ -32,7 +32,7 @@ location: https://github.com/tc39/proposal-amount/
   <emu-intro id="sec-amount-intro">
     <h1>Introduction</h1>
     <p>An Amount is an object that wraps a numeric value—as a Number, BigInt, or String—together with an optional unit (e.g., mile, kilogram, EUR, JPY, USD-per-mile). One can intuitively understand an Amount as a value that, so to speak, knows what it is measuring.</p>
-    <p>When precision options (such as fractionDigits or significantDigits) are applied, or when unit conversion is performed, the numeric value is stored as a <dfn id="dfn-decimal-digit-string">decimal digit string</dfn>, which is a String in |StrDecimalLiteral| form or *"NaN"*. Otherwise, the original JavaScript value type (Number, BigInt, or String) is retained.</p>
+    <p>When precision options (such as fractionDigits or significantDigits) are applied, or when unit conversion is performed, finite numeric values are stored as a <dfn id="dfn-decimal-digit-string">decimal digit string</dfn>: a String in |StrDecimalLiteral| form. Non-finite values are stored as the Number values *NaN*, *+&infin;*<sub>𝔽</sub>, or *-&infin;*<sub>𝔽</sub>. Otherwise, the original JavaScript value type (Number, BigInt, or String) is retained.</p>
     <p>Rounding a mathematical value is an important part of this spec. When we say <dfn id="dfn-amount-rounding-mode">rounding mode</dfn> in this specification we simply refer to <emu-xref href="#table-intl-rounding-modes">ECMA-402's definition</emu-xref>.</p>
   </emu-intro>
 
@@ -203,14 +203,11 @@ location: https://github.com/tc39/proposal-amount/
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It returns _v_ rendered in canonical exponential notation: an optional minus sign, a mantissa with one non-zero integer digit (or *"0"*), an optional fractional part, *"e"*, an explicit sign, and an unpadded base-10 exponent. The number of significant digits in the result equals the number of significant digits in _v_. If _v_ is *"NaN"*, *"Infinity"*, or *"-Infinity"*, it is returned unchanged.</dd>
+          <dd>It returns _v_ rendered in canonical exponential notation: an optional minus sign, a mantissa with one non-zero integer digit (or *"0"*), an optional fractional part, *"e"*, an explicit sign, and an unpadded base-10 exponent. The number of significant digits in the result equals the number of significant digits in _v_.</dd>
         </dl>
         <emu-alg>
           1. Let _intlMV_ be ! ToIntlMathematicalValue(_v_).
           1. Let _value_ be _intlMV_.[[Value]].
-          1. If _value_ is ~not-a-number~, return *"NaN"*.
-          1. If _value_ is ~positive-infinity~, return *"Infinity"*.
-          1. If _value_ is ~negative-infinity~, return *"-Infinity"*.
           1. Let _digitCount_ be _intlMV_.[[StringDigitCount]].
           1. Let _sign_ be the empty String.
           1. If _value_ is ~negative-zero~, then
@@ -351,10 +348,16 @@ location: https://github.com/tc39/proposal-amount/
           1. Let _value_ be _x_.
         1. Else,
           1. Assert: _x_ is a String.
-          1. Let _formatter_ be CreateFormatterObject(_roundingMode_, _fractionDigits_, _fractionDigits_, _significantDigits_, _significantDigits_, *undefined*).
           1. Let _intlMV_ be ! ToIntlMathematicalValue(_x_).
-          1. Let _formatted_ be FormatNumericToString(_formatter_, _intlMV_.[[Value]], _intlMV_.[[StringDigitCount]]).
-          1. Let _value_ be RenderDigitStringInExponentialNotation(_formatted_.[[FormattedString]]).
+          1. Let _mv_ be _intlMV_.[[Value]].
+          1. If _mv_ is ~positive-infinity~, then
+            1. Let _value_ be *+&infin;*<sub>𝔽</sub>.
+          1. Else if _mv_ is ~negative-infinity~, then
+            1. Let _value_ be *-&infin;*<sub>𝔽</sub>.
+          1. Else,
+            1. Let _formatter_ be CreateFormatterObject(_roundingMode_, _fractionDigits_, _fractionDigits_, _significantDigits_, _significantDigits_, *undefined*).
+            1. Let _formatted_ be FormatNumericToString(_formatter_, _mv_, _intlMV_.[[StringDigitCount]]).
+            1. Let _value_ be RenderDigitStringInExponentialNotation(_formatted_.[[FormattedString]]).
         1. Let _O_ be OrdinaryObjectCreate(%Amount.prototype%, « [[AmountValue]], [[Unit]] »).
         1. Set _O_.[[AmountValue]] to _value_.
         1. Set _O_.[[Unit]] to _unit_.

--- a/spec.emu
+++ b/spec.emu
@@ -198,7 +198,7 @@ location: https://github.com/tc39/proposal-amount/
 
       <emu-clause id="sec-amount-renderinexponentialnotation" type="abstract operation">
         <h1>RenderInExponentialNotation (
-          _v_: a mathematical value, ~negative-zero~, ~positive-infinity~, ~negative-infinity~, or ~not-a-number~,
+          _v_: a mathematical value,
           _sigDigits_: a positive integer
         ): a String
         </h1>
@@ -207,12 +207,8 @@ location: https://github.com/tc39/proposal-amount/
           <dd>It returns _v_ rendered in canonical exponential notation with _sigDigits_ significant digits: an optional minus sign, a mantissa with one integer digit, an optional fractional part of length _sigDigits_ - 1, *"e"*, an explicit sign, and an unpadded base-10 exponent.</dd>
         </dl>
         <emu-alg>
-          1. Assert: _v_ is a mathematical value or ~negative-zero~.
           1. Let _sign_ be the empty String.
-          1. If _v_ is ~negative-zero~, then
-            1. Set _sign_ to *"-"*.
-            1. Set _v_ to 0.
-          1. Else if _v_ &lt; 0, then
+          1. If _v_ &lt; 0, then
             1. Set _sign_ to *"-"*.
             1. Set _v_ to -_v_.
           1. If _v_ = 0, then
@@ -338,7 +334,9 @@ location: https://github.com/tc39/proposal-amount/
             1. Let _formatter_ be CreateFormatterObject(_roundingMode_, _fractionDigits_, _fractionDigits_, _significantDigits_, _significantDigits_, *undefined*).
             1. Let _formatted_ be FormatNumericToString(_formatter_, _mv_, _intlMV_.[[StringDigitCount]]).
             1. Let _formattedMV_ be ! ToIntlMathematicalValue(_formatted_.[[FormattedString]]).
-            1. Let _value_ be RenderInExponentialNotation(_formattedMV_.[[Value]], _formattedMV_.[[StringDigitCount]]).
+            1. Let _resolvedValue_ be _formattedMV_.[[Value]].
+            1. If _resolvedValue_ is ~negative-zero~, set _resolvedValue_ to 0.
+            1. Let _value_ be RenderInExponentialNotation(_resolvedValue_, _formattedMV_.[[StringDigitCount]]).
         1. Let _O_ be OrdinaryObjectCreate(%Amount.prototype%, « [[AmountValue]], [[Unit]] »).
         1. Set _O_.[[AmountValue]] to _value_.
         1. Set _O_.[[Unit]] to _unit_.
@@ -455,7 +453,9 @@ location: https://github.com/tc39/proposal-amount/
         1. Let _formatter_ be CreateFormatterObject(_roundingMode_, _fractionDigits_, _fractionDigits_, _significantDigits_, _significantDigits_, *undefined*).
         1. Let _formatted_ be FormatNumericToString(_formatter_, ℝ(_convertedValue_), 0).
         1. Let _formattedMV_ be ! ToIntlMathematicalValue(_formatted_.[[FormattedString]]).
-        1. Set _result_.[[AmountValue]] to RenderInExponentialNotation(_formattedMV_.[[Value]], _formattedMV_.[[StringDigitCount]]).
+        1. Let _resolvedValue_ be _formattedMV_.[[Value]].
+        1. If _resolvedValue_ is ~negative-zero~, set _resolvedValue_ to 0.
+        1. Set _result_.[[AmountValue]] to RenderInExponentialNotation(_resolvedValue_, _formattedMV_.[[StringDigitCount]]).
       1. Else,
         1. Set _result_.[[AmountValue]] to _convertedValue_.
       1. Set _result_.[[Unit]] to _targetUnit_.

--- a/spec.emu
+++ b/spec.emu
@@ -345,6 +345,9 @@ location: https://github.com/tc39/proposal-amount/
       <emu-note>
         <p>When no precision options are given, Number and BigInt arguments are stored directly in [[AmountValue]], preserving the original type. String arguments and values resulting from precision options are stored as a String in canonical exponential notation, preserving the precision implied by the input.</p>
       </emu-note>
+      <emu-note>
+        <p>The canonical exponential representation does not preserve the sign of negative zero. Both <code>new Amount(-0).toString()</code> and <code>new Amount("-0").toString()</code> return *"0e+0[]"*.</p>
+      </emu-note>
       <emu-note type="editor">
 	<p>
 	  We intend to move 402's FormatNumericToString, and its dependent AOs, to 262, possibly renamed.

--- a/spec.emu
+++ b/spec.emu
@@ -414,8 +414,8 @@ location: https://github.com/tc39/proposal-amount/
       1. Else,
         1. Assert: _v_ is a BigInt.
         1. Let _valueStr_ be RenderBigIntInExponentialNotation(_v_).
-      1. If _u_ is *undefined*, return the string-concatenation of *"["*, _valueStr_, and *" ∅]"*.
-      1. Return the string-concatenation of *"["*, _valueStr_, *" "*, _u_, and *"]"*.
+      1. If _u_ is *undefined*, return the string-concatenation of _valueStr_ and *"[]"*.
+      1. Return the string-concatenation of _valueStr_, *"["*, _u_, and *"]"*.
     </emu-alg>
   </emu-clause>
 

--- a/spec.emu
+++ b/spec.emu
@@ -196,8 +196,8 @@ location: https://github.com/tc39/proposal-amount/
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-amount-renderstringinexponentialnotation" type="abstract operation">
-        <h1>RenderStringInExponentialNotation (
+      <emu-clause id="sec-amount-renderdigitstringinexponentialnotation" type="abstract operation">
+        <h1>RenderDigitStringInExponentialNotation (
           _v_: a String
         ): a String
         </h1>
@@ -354,7 +354,7 @@ location: https://github.com/tc39/proposal-amount/
           1. Let _formatter_ be CreateFormatterObject(_roundingMode_, _fractionDigits_, _fractionDigits_, _significantDigits_, _significantDigits_, *undefined*).
           1. Let _intlMV_ be ! ToIntlMathematicalValue(_x_).
           1. Let _formatted_ be FormatNumericToString(_formatter_, _intlMV_.[[Value]], _intlMV_.[[StringDigitCount]]).
-          1. Let _value_ be RenderStringInExponentialNotation(_formatted_.[[FormattedString]]).
+          1. Let _value_ be RenderDigitStringInExponentialNotation(_formatted_.[[FormattedString]]).
         1. Let _O_ be OrdinaryObjectCreate(%Amount.prototype%, « [[AmountValue]], [[Unit]] »).
         1. Set _O_.[[AmountValue]] to _value_.
         1. Set _O_.[[Unit]] to _unit_.
@@ -459,7 +459,7 @@ location: https://github.com/tc39/proposal-amount/
       1. If _convertedValue_ is finite and (_fractionDigits_ is not *undefined* or _significantDigits_ is not *undefined*), then
         1. Let _formatter_ be CreateFormatterObject(_roundingMode_, _fractionDigits_, _fractionDigits_, _significantDigits_, _significantDigits_, *undefined*).
         1. Let _formatted_ be FormatNumericToString(_formatter_, ℝ(_convertedValue_), 0).
-        1. Set _result_.[[AmountValue]] to RenderStringInExponentialNotation(_formatted_.[[FormattedString]]).
+        1. Set _result_.[[AmountValue]] to RenderDigitStringInExponentialNotation(_formatted_.[[FormattedString]]).
       1. Else,
         1. Set _result_.[[AmountValue]] to _convertedValue_.
       1. Set _result_.[[Unit]] to _targetUnit_.

--- a/spec.emu
+++ b/spec.emu
@@ -347,8 +347,9 @@ location: https://github.com/tc39/proposal-amount/
       1. Else,
         1. Assert: _v_ is a BigInt.
         1. Let _valueStr_ be BigInt::toString(_v_, 10).
-      1. If _u_ is *undefined*, return the string-concatenation of _valueStr_ and *"[]"*.
-      1. Return the string-concatenation of _valueStr_, *"["*, _u_, and *"]"*.
+      1. TODO: Normalize _valueStr_ to use exponential notation.
+      1. If _u_ is *undefined*, return the string-concatenation of *"["*, _valueStr_, and *" ∅]"*.
+      1. Return the string-concatenation of *"["*, _valueStr_, *" "*, _u_, and *"]"*.
     </emu-alg>
   </emu-clause>
 

--- a/spec.emu
+++ b/spec.emu
@@ -353,7 +353,9 @@ location: https://github.com/tc39/proposal-amount/
           1. Assert: _x_ is a String.
           1. Let _intlMV_ be ! ToIntlMathematicalValue(_x_).
           1. Let _mv_ be _intlMV_.[[Value]].
-          1. If _mv_ is ~positive-infinity~, then
+          1. If _mv_ is ~not-a-number~, then
+            1. Let _value_ be *NaN*.
+          1. Else if _mv_ is ~positive-infinity~, then
             1. Let _value_ be *+&infin;*<sub>𝔽</sub>.
           1. Else if _mv_ is ~negative-infinity~, then
             1. Let _value_ be *-&infin;*<sub>𝔽</sub>.

--- a/spec.emu
+++ b/spec.emu
@@ -198,17 +198,20 @@ location: https://github.com/tc39/proposal-amount/
 
       <emu-clause id="sec-amount-renderinexponentialnotation" type="abstract operation">
         <h1>RenderInExponentialNotation (
-          _v_: a mathematical value,
+          _v_: a mathematical value or ~negative-zero~,
           _sigDigits_: a positive integer
         ): a String
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It returns _v_ rendered in canonical exponential notation with _sigDigits_ significant digits: an optional minus sign, a mantissa with one integer digit, an optional fractional part of length _sigDigits_ - 1, *"e"*, an explicit sign, and an unpadded base-10 exponent.</dd>
+          <dd>It returns _v_ rendered in canonical exponential notation with _sigDigits_ significant digits: an optional minus sign, a mantissa with one integer digit, an optional fractional part of length _sigDigits_ - 1, *"e"*, an explicit sign, and an unpadded base-10 exponent. The sign of negative zero is preserved.</dd>
         </dl>
         <emu-alg>
           1. Let _sign_ be the empty String.
-          1. If _v_ &lt; 0, then
+          1. If _v_ is ~negative-zero~, then
+            1. Set _sign_ to *"-"*.
+            1. Set _v_ to 0.
+          1. Else if _v_ &lt; 0, then
             1. Set _sign_ to *"-"*.
             1. Set _v_ to -_v_.
           1. If _v_ = 0, then
@@ -334,9 +337,7 @@ location: https://github.com/tc39/proposal-amount/
             1. Let _formatter_ be CreateFormatterObject(_roundingMode_, _fractionDigits_, _fractionDigits_, _significantDigits_, _significantDigits_, *undefined*).
             1. Let _formatted_ be FormatNumericToString(_formatter_, _mv_, _intlMV_.[[StringDigitCount]]).
             1. Let _formattedMV_ be ! ToIntlMathematicalValue(_formatted_.[[FormattedString]]).
-            1. Let _resolvedValue_ be _formattedMV_.[[Value]].
-            1. If _resolvedValue_ is ~negative-zero~, set _resolvedValue_ to 0.
-            1. Let _value_ be RenderInExponentialNotation(_resolvedValue_, _formattedMV_.[[StringDigitCount]]).
+            1. Let _value_ be RenderInExponentialNotation(_formattedMV_.[[Value]], _formattedMV_.[[StringDigitCount]]).
         1. Let _O_ be OrdinaryObjectCreate(%Amount.prototype%, « [[AmountValue]], [[Unit]] »).
         1. Set _O_.[[AmountValue]] to _value_.
         1. Set _O_.[[Unit]] to _unit_.
@@ -344,9 +345,6 @@ location: https://github.com/tc39/proposal-amount/
       </emu-alg>
       <emu-note>
         <p>When no precision options are given, Number and BigInt arguments are stored directly in [[AmountValue]], preserving the original type. String arguments and values resulting from precision options are stored as a String in canonical exponential notation, preserving the precision implied by the input.</p>
-      </emu-note>
-      <emu-note>
-        <p>The canonical exponential representation does not preserve the sign of negative zero. Both <code>new Amount(-0).toString()</code> and <code>new Amount("-0").toString()</code> return *"0e+0[]"*.</p>
       </emu-note>
       <emu-note type="editor">
 	<p>
@@ -404,7 +402,9 @@ location: https://github.com/tc39/proposal-amount/
         1. Else,
           1. Let _decimalStr_ be Number::toString(_v_, 10).
           1. Let _intlMV_ be ! ToIntlMathematicalValue(_decimalStr_).
-          1. Let _valueStr_ be RenderInExponentialNotation(_intlMV_.[[Value]], _intlMV_.[[StringDigitCount]]).
+          1. Let _mv_ be _intlMV_.[[Value]].
+          1. If _v_ is *-0*<sub>𝔽</sub>, set _mv_ to ~negative-zero~.
+          1. Let _valueStr_ be RenderInExponentialNotation(_mv_, _intlMV_.[[StringDigitCount]]).
       1. Else,
         1. Assert: _v_ is a BigInt.
         1. Let _digits_ be BigInt::toString(_v_, 10).
@@ -456,9 +456,7 @@ location: https://github.com/tc39/proposal-amount/
         1. Let _formatter_ be CreateFormatterObject(_roundingMode_, _fractionDigits_, _fractionDigits_, _significantDigits_, _significantDigits_, *undefined*).
         1. Let _formatted_ be FormatNumericToString(_formatter_, ℝ(_convertedValue_), 0).
         1. Let _formattedMV_ be ! ToIntlMathematicalValue(_formatted_.[[FormattedString]]).
-        1. Let _resolvedValue_ be _formattedMV_.[[Value]].
-        1. If _resolvedValue_ is ~negative-zero~, set _resolvedValue_ to 0.
-        1. Set _result_.[[AmountValue]] to RenderInExponentialNotation(_resolvedValue_, _formattedMV_.[[StringDigitCount]]).
+        1. Set _result_.[[AmountValue]] to RenderInExponentialNotation(_formattedMV_.[[Value]], _formattedMV_.[[StringDigitCount]]).
       1. Else,
         1. Set _result_.[[AmountValue]] to _convertedValue_.
       1. Set _result_.[[Unit]] to _targetUnit_.

--- a/spec.emu
+++ b/spec.emu
@@ -196,32 +196,39 @@ location: https://github.com/tc39/proposal-amount/
         </emu-note>
       </emu-clause>
 
-      <emu-clause id="sec-amount-renderdigitstringinexponentialnotation" type="abstract operation">
-        <h1>RenderDigitStringInExponentialNotation (
-          _v_: a String
+      <emu-clause id="sec-amount-renderinexponentialnotation" type="abstract operation">
+        <h1>RenderInExponentialNotation (
+          _v_: a mathematical value, ~negative-zero~, ~positive-infinity~, ~negative-infinity~, or ~not-a-number~,
+          _sigDigits_: a positive integer
         ): a String
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It returns _v_ rendered in canonical exponential notation: an optional minus sign, a mantissa with one non-zero integer digit (or *"0"*), an optional fractional part, *"e"*, an explicit sign, and an unpadded base-10 exponent. The number of significant digits in the result equals the number of significant digits in _v_.</dd>
+          <dd>It returns _v_ rendered in canonical exponential notation with _sigDigits_ significant digits: an optional minus sign, a mantissa with one integer digit, an optional fractional part of length _sigDigits_ - 1, *"e"*, an explicit sign, and an unpadded base-10 exponent.</dd>
         </dl>
         <emu-alg>
-          1. Let _intlMV_ be ! ToIntlMathematicalValue(_v_).
-          1. Let _value_ be _intlMV_.[[Value]].
-          1. Let _digitCount_ be _intlMV_.[[StringDigitCount]].
+          1. Assert: _v_ is a mathematical value or ~negative-zero~.
           1. Let _sign_ be the empty String.
-          1. If _value_ is ~negative-zero~, then
+          1. If _v_ is ~negative-zero~, then
             1. Set _sign_ to *"-"*.
-            1. Set _value_ to 0.
-          1. Else if _value_ &lt; 0, then
+            1. Set _v_ to 0.
+          1. Else if _v_ &lt; 0, then
             1. Set _sign_ to *"-"*.
-            1. Set _value_ to -_value_.
-          1. If _value_ = 0, let _exponent_ be 0; else, let _exponent_ be the unique integer such that 10<sup>_exponent_</sup> ≤ _value_ &lt; 10<sup>_exponent_ + 1</sup>.
-          1. Let _mantissa_ be _value_ × 10<sup>-_exponent_</sup>.
-          1. Let _fracDigits_ be _digitCount_ - 1.
-          1. Let _formatter_ be CreateFormatterObject(*"halfEven"*, _fracDigits_, _fracDigits_, *undefined*, *undefined*, *undefined*).
-          1. Let _formatted_ be FormatNumericToString(_formatter_, _mantissa_, _digitCount_).
-          1. Let _mantissaStr_ be _formatted_.[[FormattedString]].
+            1. Set _v_ to -_v_.
+          1. If _v_ = 0, then
+            1. Let _exponent_ be 0.
+            1. Let _mantissaInt_ be 0.
+          1. Else,
+            1. Let _exponent_ be the unique integer such that 10<sup>_exponent_</sup> ≤ _v_ &lt; 10<sup>_exponent_ + 1</sup>.
+            1. Let _mantissaInt_ be _v_ × 10<sup>_sigDigits_ - 1 - _exponent_</sup>.
+          1. Assert: _mantissaInt_ is a non-negative integer with at most _sigDigits_ decimal digits.
+          1. Let _intStr_ be the base-10 String representation of _mantissaInt_ with no leading zeros, or *"0"* if _mantissaInt_ is 0.
+          1. Repeat, while the length of _intStr_ is less than _sigDigits_,
+            1. Set _intStr_ to the string-concatenation of *"0"* and _intStr_.
+          1. If _sigDigits_ = 1, then
+            1. Let _mantissaStr_ be _intStr_.
+          1. Else,
+            1. Let _mantissaStr_ be the string-concatenation of the substring of _intStr_ from 0 to 1, *"."*, and the substring of _intStr_ from 1.
           1. If _exponent_ ≥ 0, let _expSign_ be *"+"*; else let _expSign_ be *"-"*.
           1. Let _expStr_ be the unique base-10 String representation of abs(_exponent_) with no leading zeros.
           1. Return the string-concatenation of _sign_, _mantissaStr_, *"e"*, _expSign_, and _expStr_.
@@ -229,38 +236,6 @@ location: https://github.com/tc39/proposal-amount/
         <emu-note type="editor">
           <p>TODO: this algorithm performs essentially the same work as the latter portion of <emu-xref href="#sec-number.prototype.toexponential">Number.prototype.toExponential</emu-xref> (the part following its initial argument-coercion and special-value handling). We should extract a shared abstract operation from that algorithm and use it both there and here, to ensure the two stay in sync.</p>
         </emu-note>
-      </emu-clause>
-
-      <emu-clause id="sec-amount-renderbigintinexponentialnotation" type="abstract operation">
-        <h1>RenderBigIntInExponentialNotation (
-          _b_: a BigInt
-        ): a String
-        </h1>
-        <dl class="header">
-          <dt>description</dt>
-          <dd>It returns _b_ rendered in canonical exponential notation: an optional minus sign, a single non-zero integer digit (or *"0"* when _b_ is *0*<sub>ℤ</sub>), optionally followed by *"."* and additional fractional digits when more precision is required, *"e+"*, and a base-10 exponent without leading zeros. Trailing zeros of _b_ are absorbed into the exponent.</dd>
-        </dl>
-        <emu-alg>
-          1. If _b_ = *0*<sub>ℤ</sub>, return *"0e+0"*.
-          1. Let _sign_ be the empty String.
-          1. If _b_ &lt; *0*<sub>ℤ</sub>, then
-            1. Set _sign_ to *"-"*.
-            1. Set _b_ to -_b_.
-          1. Let _digits_ be BigInt::toString(_b_, 10).
-          1. Let _len_ be the length of _digits_.
-          1. Let _trailingZeros_ be the largest non-negative integer _k_ such that the last _k_ code units of _digits_ are all 0x0030 (DIGIT ZERO).
-          1. Let _significantLen_ be _len_ - _trailingZeros_.
-          1. Let _significantDigits_ be the substring of _digits_ from 0 to _significantLen_.
-          1. If _significantLen_ = 1, then
-            1. Let _mantissaStr_ be _significantDigits_.
-          1. Else,
-            1. Let _intDigit_ be the substring of _significantDigits_ from 0 to 1.
-            1. Let _fracDigits_ be the substring of _significantDigits_ from 1 to _significantLen_.
-            1. Let _mantissaStr_ be the string-concatenation of _intDigit_, *"."*, and _fracDigits_.
-          1. Let _exponent_ be _len_ - 1.
-          1. Let _expStr_ be the unique base-10 String representation of _exponent_ with no leading zeros.
-          1. Return the string-concatenation of _sign_, _mantissaStr_, *"e+"*, and _expStr_.
-        </emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-amount-getunitconversionfactor" type="abstract operation">
@@ -362,7 +337,8 @@ location: https://github.com/tc39/proposal-amount/
           1. Else,
             1. Let _formatter_ be CreateFormatterObject(_roundingMode_, _fractionDigits_, _fractionDigits_, _significantDigits_, _significantDigits_, *undefined*).
             1. Let _formatted_ be FormatNumericToString(_formatter_, _mv_, _intlMV_.[[StringDigitCount]]).
-            1. Let _value_ be RenderDigitStringInExponentialNotation(_formatted_.[[FormattedString]]).
+            1. Let _formattedMV_ be ! ToIntlMathematicalValue(_formatted_.[[FormattedString]]).
+            1. Let _value_ be RenderInExponentialNotation(_formattedMV_.[[Value]], _formattedMV_.[[StringDigitCount]]).
         1. Let _O_ be OrdinaryObjectCreate(%Amount.prototype%, « [[AmountValue]], [[Unit]] »).
         1. Set _O_.[[AmountValue]] to _value_.
         1. Set _O_.[[Unit]] to _unit_.
@@ -426,10 +402,13 @@ location: https://github.com/tc39/proposal-amount/
           1. Let _valueStr_ be *"-Infinity"*.
         1. Else,
           1. Let _decimalStr_ be Number::toString(_v_, 10).
-          1. Let _valueStr_ be RenderDigitStringInExponentialNotation(_decimalStr_).
+          1. Let _intlMV_ be ! ToIntlMathematicalValue(_decimalStr_).
+          1. Let _valueStr_ be RenderInExponentialNotation(_intlMV_.[[Value]], _intlMV_.[[StringDigitCount]]).
       1. Else,
         1. Assert: _v_ is a BigInt.
-        1. Let _valueStr_ be RenderBigIntInExponentialNotation(_v_).
+        1. Let _digits_ be BigInt::toString(_v_, 10).
+        1. Let _intlMV_ be ! ToIntlMathematicalValue(_digits_).
+        1. Let _valueStr_ be RenderInExponentialNotation(_intlMV_.[[Value]], _intlMV_.[[StringDigitCount]]).
       1. If _u_ is *undefined*, return the string-concatenation of _valueStr_ and *"[]"*.
       1. Return the string-concatenation of _valueStr_, *"["*, _u_, and *"]"*.
     </emu-alg>
@@ -475,7 +454,8 @@ location: https://github.com/tc39/proposal-amount/
       1. If _convertedValue_ is finite and (_fractionDigits_ is not *undefined* or _significantDigits_ is not *undefined*), then
         1. Let _formatter_ be CreateFormatterObject(_roundingMode_, _fractionDigits_, _fractionDigits_, _significantDigits_, _significantDigits_, *undefined*).
         1. Let _formatted_ be FormatNumericToString(_formatter_, ℝ(_convertedValue_), 0).
-        1. Set _result_.[[AmountValue]] to RenderDigitStringInExponentialNotation(_formatted_.[[FormattedString]]).
+        1. Let _formattedMV_ be ! ToIntlMathematicalValue(_formatted_.[[FormattedString]]).
+        1. Set _result_.[[AmountValue]] to RenderInExponentialNotation(_formattedMV_.[[Value]], _formattedMV_.[[StringDigitCount]]).
       1. Else,
         1. Set _result_.[[AmountValue]] to _convertedValue_.
       1. Set _result_.[[Unit]] to _targetUnit_.

--- a/spec.emu
+++ b/spec.emu
@@ -226,6 +226,9 @@ location: https://github.com/tc39/proposal-amount/
           1. Let _expStr_ be the unique base-10 String representation of abs(_exponent_) with no leading zeros.
           1. Return the string-concatenation of _sign_, _mantissaStr_, *"e"*, _expSign_, and _expStr_.
         </emu-alg>
+        <emu-note type="editor">
+          <p>TODO: this algorithm performs essentially the same work as the latter portion of <emu-xref href="#sec-number.prototype.toexponential">Number.prototype.toExponential</emu-xref> (the part following its initial argument-coercion and special-value handling). We should extract a shared abstract operation from that algorithm and use it both there and here, to ensure the two stay in sync.</p>
+        </emu-note>
       </emu-clause>
 
       <emu-clause id="sec-amount-renderbigintinexponentialnotation" type="abstract operation">

--- a/spec.emu
+++ b/spec.emu
@@ -206,13 +206,12 @@ location: https://github.com/tc39/proposal-amount/
           <dd>It returns _v_ rendered in canonical exponential notation: an optional minus sign, a mantissa with one non-zero integer digit (or *"0"*), an optional fractional part, *"e"*, an explicit sign, and an unpadded base-10 exponent. The number of significant digits in the result equals the number of significant digits in _v_. If _v_ is *"NaN"*, *"Infinity"*, or *"-Infinity"*, it is returned unchanged.</dd>
         </dl>
         <emu-alg>
-          1. If _v_ is *"NaN"*, *"Infinity"*, or *"-Infinity"*, return _v_.
-          1. Let _text_ be StringToCodePoints(_v_).
-          1. Let _literal_ be ParseText(_text_, |StrDecimalLiteral|).
-          1. Assert: _literal_ is not a List of errors.
-          1. Let _stringData_ be StringIntlMV of _literal_.
-          1. Let _value_ be _stringData_[0].
-          1. Let _digitCount_ be _stringData_[1].
+          1. Let _intlMV_ be ! ToIntlMathematicalValue(_v_).
+          1. Let _value_ be _intlMV_.[[Value]].
+          1. If _value_ is ~not-a-number~, return *"NaN"*.
+          1. If _value_ is ~positive-infinity~, return *"Infinity"*.
+          1. If _value_ is ~negative-infinity~, return *"-Infinity"*.
+          1. Let _digitCount_ be _intlMV_.[[StringDigitCount]].
           1. Let _sign_ be the empty String.
           1. If _value_ is ~negative-zero~, then
             1. Set _sign_ to *"-"*.


### PR DESCRIPTION
Resolves the toString TODO with a new AO, `RenderInExponentialNotation(value, sigDigits)`, which renders a mathematical value in canonical exponential notation.

BigInt rendering here doesn't strip trailing zeros, so `100000n` now serializes as `"1.00000e+5"`, which makes things uniform with how `Numbers` and `Strings` are handled.

An editorial note records that the AO does essentially overlaps with `Number.prototype.toExponential` and that the two should eventually share an extracted operation.