### PR TITLE
Fix constructor logic: Always apply rounding if fractionDigits or significantDigits is set

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -308,36 +308,39 @@ location: https://github.com/tc39/proposal-amount/
       <li>may be used as the value of an *extends* clause of a class definition.</li>
     </ul>
     <emu-clause id="sec-the-amount-constructor-value">
-      <h1>Amount ( _x_ [ , _opts_ ] )</h1>
+      <h1>Amount ( _value_ [ , _options_ ] )</h1>
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
-        1. If _x_ is not a Number, not a BigInt, and not a String, throw a *TypeError* exception.
-        1. If _x_ is a String, then
-          1. Let _text_ be StringToCodePoints(_x_).
-          1. Let _parsed_ be ParseText(_text_, |StringNumericLiteral|).
+        1. If _value_ is a String, then
+          1. Let _parsed_ be ParseText(_value_, |StringNumericLiteral|).
           1. If _parsed_ is a List of errors, throw a *RangeError* exception.
-        1. Let _validatedOpts_ be ? GetAmountOptions(_opts_).
+        1. Else if _value_ is not a Number or a BigInt, then
+          1. Throw a *TypeError* exception.
+        1. Let _validatedOpts_ be ? GetAmountOptions(_options_).
         1. Let _roundingMode_ be _validatedOpts_.[[RoundingMode]].
         1. Let _fractionDigits_ be _validatedOpts_.[[FractionDigits]].
         1. Let _significantDigits_ be _validatedOpts_.[[SignificantDigits]].
         1. Let _unit_ be _validatedOpts_.[[Unit]].
-        1. If _x_ is a Number or _x_ is a BigInt, then
-          1. Let _value_ be _x_.
-        1. Else,
-          1. Assert: _x_ is a String.
-          1. Let _intlMV_ be ! ToIntlMathematicalValue(_x_).
+        1. If _value_ is a String, then
+          1. Let _intlMV_ be the StringIntlMV of _parsed_.
           1. Let _mv_ be _intlMV_.[[Value]].
           1. If _mv_ is ~not-a-number~, then
-            1. Let _value_ be *NaN*.
+            1. Set _value_ to *NaN*.
           1. Else if _mv_ is ~positive-infinity~, then
-            1. Let _value_ be *+&infin;*<sub>𝔽</sub>.
+            1. Set _value_ to *+∞*<sub>𝔽</sub>.
           1. Else if _mv_ is ~negative-infinity~, then
-            1. Let _value_ be *-&infin;*<sub>𝔽</sub>.
+            1. Set _value_ to *-∞*<sub>𝔽</sub>.
           1. Else,
+            1. Set _value_ to RenderInExponentialNotation(_mv_, _intlMV_.[[StringDigitCount]]).
+        1. If _fractionDigits_ is not *undefined* or _significantDigits_ is not *undefined*, then
+          1. If _value_ is not a Number or _value_ is a finite Number, then
             1. Let _formatter_ be CreateFormatterObject(_roundingMode_, _fractionDigits_, _fractionDigits_, _significantDigits_, _significantDigits_, *undefined*).
-            1. Let _formatted_ be FormatNumericToString(_formatter_, _mv_, _intlMV_.[[StringDigitCount]]).
-            1. Let _formattedMV_ be ! ToIntlMathematicalValue(_formatted_.[[FormattedString]]).
-            1. Let _value_ be RenderInExponentialNotation(_formattedMV_.[[Value]], _formattedMV_.[[StringDigitCount]]).
+            1. Let _fmtMV_ be the MV of _value_.
+            1. Let _fmt_ be FormatNumericToString(_formatter_, _fmtMV_, 0).
+            1. Let _fmtParsed_ be ParseText(_fmt_.[[FormattedString]], |StringNumericLiteral|).
+            1. Assert: _fmtParsed_ is an instance of |StringNumericLiteral|.
+            1. Let _fmtIntlMV_ be the StringIntlMV of _fmtParsed_.
+            1. Let _value_ be RenderInExponentialNotation(_fmtIntlMV_.[[Value]], _fmtIntlMV_.[[StringDigitCount]]).
         1. Let _O_ be OrdinaryObjectCreate(%Amount.prototype%, « [[AmountValue]], [[Unit]] »).
         1. Set _O_.[[AmountValue]] to _value_.
         1. Set _O_.[[Unit]] to _unit_.


### PR DESCRIPTION
Fixes this part of #108:
> The spec's note in the `Amount` constructor is incorrect: The spec always stores Number and BigInt arguments directly in [[AmountValue]], regardless of the rounding options.