### PR TITLE
Be explicit about the Number-to-MV conversion in `.convertTo()`

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -457,7 +457,8 @@ location: https://github.com/tc39/proposal-amount/
       1. Let _result_ be OrdinaryObjectCreate(%Amount.prototype%, « [[AmountValue]], [[Unit]] »).
       1. If _convertedValue_ is finite and (_fractionDigits_ is not *undefined* or _significantDigits_ is not *undefined*), then
         1. Let _formatter_ be CreateFormatterObject(_roundingMode_, _fractionDigits_, _fractionDigits_, _significantDigits_, _significantDigits_, *undefined*).
-        1. Let _formatted_ be FormatNumericToString(_formatter_, ℝ(_convertedValue_), 0).
+        1. Let _intlMV_ be ! ToIntlMathematicalValue(_convertedValue_).
+        1. Let _formatted_ be FormatNumericToString(_formatter_, _intlMV_.[[Value]], 0).
         1. Let _formattedMV_ be ! ToIntlMathematicalValue(_formatted_.[[FormattedString]]).
         1. Set _result_.[[AmountValue]] to RenderInExponentialNotation(_formattedMV_.[[Value]], _formattedMV_.[[StringDigitCount]]).
       1. Else,


### PR DESCRIPTION
Rather than getting an MV using ℝ(_convertedValue_), let's do the same thing Intl.NumberFormat does, and call ToIntlMathematicalValue(_convertedValue_), which effectively gets us ℝ(Number::toString(_convertedValue_, 10)).

This fixes the following part of #108:
> Converting "0.15" meters to meters with conversion options fractionDigits=1 and the default rounding mode "halfEven" produces "1e-1" meters, which is incorrect. The correct answer is "2e-1" meters. Again, multiple rounding is the culprit here.