### PR TITLE
Unit string shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Note: ⚠️  All property/method names up for bikeshedding.
 * `new Amount(value[, options])`. Constructs an Amount with the numerical value of `value`
   and optional `options`, of which the following are supported (all being optional):
   * `unit` (String): A unit identifier associated with the numerical value, which must not be an empty string.
+    As a shorthand, `options` may be given directly as a String, which is equivalent to passing `{ unit: options }`,
+    so `new Amount(42, "meter")` is the same as `new Amount(42, { unit: "meter" })`.
   * `fractionDigits`: the number of fractional digits the mathematical value should have (can be less than, equal to, or greater than the actual number of fractional digits that the underlying mathematical value has when rendered as a decimal digit string)
   * `significantDigits`: the number of significant digits that the mathematical value should have  (can be less than, equal to, or greater than the actual number of significant digits that the underlying mathematical value has when rendered as a decimal digit string)
   * `roundingMode`: one of the seven supported Intl rounding modes. This option is used when the `fractionDigits` and `significantDigits` options are provided and rounding is necessary to ensure that the value really does have the specified number of fraction/significant digits.
@@ -88,7 +90,9 @@ The object prototype would provide the following methods:
   with the value of the new Amount being the value of the Amount it is called on converted to the new scale.
   The `options` object supports the following properties:
 
-  * `unit` (String): An explicit conversion target unit identifier
+  * `unit` (String): An explicit conversion target unit identifier.
+    As a shorthand, `options` may be given directly as a String, which is equivalent to passing `{ unit: options }`,
+    so `amount.convertTo("milliliter")` is the same as `amount.convertTo({ unit: "milliliter" })`.
   * `locale` (String or Array of Strings or undefined):
     The locale for which the preferred unit of the corresponding category is determined.
   * `usage` (String): The use case for the Amount, such as `"person"` for a mass unit.
@@ -162,8 +166,8 @@ but the resulting Amount will of course have an appropriate `unit` set.
 For example:
 
 ```js
-let feet = new Amount(1.75, { unit: "foot" });
-feet.convertTo({ unit: "inch" }); // 21 inches
+let feet = new Amount(1.75, "foot"); // shorthand for { unit: "foot" }
+feet.convertTo("inch"); // 21 inches; shorthand for { unit: "inch" }
 feet.convertTo({ locale: "fr", usage: "person", significantDigits: 3 }); // 53.3 cm
 ```
 

--- a/spec.emu
+++ b/spec.emu
@@ -76,19 +76,25 @@ location: https://tc39.es/proposal-amount/
 
       <emu-clause id="sec-amount-getamountoptions" type="abstract operation">
         <h1>GetAmountOptions (
-          _opts_: an Object
+          _opts_: an ECMAScript language value
         ): either a normal completion containing a Record with fields [[FractionDigits]] (a non-negative integer or *undefined*), [[RoundingMode]] (a <emu-xref href="#dfn-amount-rounding-mode">rounding mode</emu-xref>), [[SignificantDigits]] (a positive integer or *undefined*), and [[Unit]] (a String or *undefined*) or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It validates the given _options_ (an ECMAScript object) for creating an Amount and returns a Record with slots set to appropriate marthematical values (or *undefined*).</dd>
+          <dd>It validates the given _opts_ for creating an Amount and returns a Record with slots set to appropriate marthematical values (or *undefined*). A String _opts_ is treated as a convenient shorthand for specifying a unit.</dd>
         </dl>
         <emu-alg>
-          1. Let _opts_ be ? GetOptionsObject(_opts_).
-          1. Let _fractionDigits_ be ? GetOption(_opts_, *"fractionDigits"*, ~number~, ~empty~, *undefined*).
-          1. Let _roundingMode_ be ? GetOption(_opts_, *"roundingMode"*, ~string~, « *"ceil"*, *"floor"*, *"expand"*, *"trunc"*, *"halfCeil"*, *"halfFloor"*, *"halfExpand"*, *"halfTrunc"*, *"halfEven"* », *"halfEven"*).
-          1. Let _significantDigits_ be ? GetOption(_opts_, *"significantDigits"*, ~number~, ~empty~, *undefined*).
-          1. Let _unit_ be ? GetOption(_opts_, *"unit"*, ~string~, ~empty~, *undefined*).
+          1. Let _fractionDigits_ be *undefined*.
+          1. Let _significantDigits_ be *undefined*.
+          1. Let _roundingMode_ be *"halfEven"*.
+          1. If _opts_ is a String, then
+            1. Let _unit_ be _opts_.
+          1. Else,
+            1. Set _opts_ to ? GetOptionsObject(_opts_).
+            1. Set _fractionDigits_ to ? GetOption(_opts_, *"fractionDigits"*, ~number~, ~empty~, *undefined*).
+            1. Set _roundingMode_ to ? GetOption(_opts_, *"roundingMode"*, ~string~, « *"ceil"*, *"floor"*, *"expand"*, *"trunc"*, *"halfCeil"*, *"halfFloor"*, *"halfExpand"*, *"halfTrunc"*, *"halfEven"* », *"halfEven"*).
+            1. Set _significantDigits_ to ? GetOption(_opts_, *"significantDigits"*, ~number~, ~empty~, *undefined*).
+            1. Let _unit_ be ? GetOption(_opts_, *"unit"*, ~string~, ~empty~, *undefined*).
           1. If _fractionDigits_ is not *undefined*, then
             1. If _significantDigits_ is not *undefined*, throw a *RangeError* exception.
             1. If _fractionDigits_ is not an integral Number, throw a *RangeError* exception.
@@ -105,19 +111,25 @@ location: https://tc39.es/proposal-amount/
 
       <emu-clause id="sec-amount-getamountconverttooptions" type="abstract operation">
         <h1>GetAmountConvertToOptions (
-          _opts_: an Object
+          _opts_: an ECMAScript language value
         ): either a normal completion containing a Record with fields [[FractionDigits]] (a non-negative integer or *undefined*), [[RoundingMode]] (a <emu-xref href="#dfn-amount-rounding-mode">rounding mode</emu-xref>), [[SignificantDigits]] (a positive integer or *undefined*), and [[Unit]] (a String or *undefined*) or a throw completion
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It validates the given _options_ (an ECMAScript object) for converting an Amount to another Amount and returns a Record with slots set to appropriate marthematical values (or *undefined*).</dd>
+          <dd>It validates the given _opts_ for converting an Amount to another Amount and returns a Record with slots set to appropriate marthematical values (or *undefined*). A String _opts_ is treated as convenient shorthand for specifying a unit.</dd>
         </dl>
         <emu-alg>
-          1. Let _opts_ be ? GetOptionsObject(_opts_).
-          1. Let _fractionDigits_ be ? GetOption(_opts_, *"fractionDigits"*, ~number~, ~empty~, *undefined*).
-          1. Let _roundingMode_ be ? GetOption(_opts_, *"roundingMode"*, ~string~, « *"ceil"*, *"floor"*, *"expand"*, *"trunc"*, *"halfCeil"*, *"halfFloor"*, *"halfExpand"*, *"halfTrunc"*, *"halfEven"* », *"halfEven"*).
-          1. Let _significantDigits_ be ? GetOption(_opts_, *"significantDigits"*, ~number~, ~empty~, *undefined*).
-          1. Let _unit_ be ? GetOption(_opts_, *"unit"*, ~string~, ~empty~, *undefined*).
+          1. Let _fractionDigits_ be *undefined*.
+          1. Let _significantDigits_ be *undefined*.
+          1. Let _roundingMode_ be *"halfEven"*.
+          1. If _opts_ is a String, then
+            1. Let _unit_ be _opts_.
+          1. Else,
+            1. Set _opts_ to ? GetOptionsObject(_opts_).
+            1. Set _fractionDigits_ to ? GetOption(_opts_, *"fractionDigits"*, ~number~, ~empty~, *undefined*).
+            1. Set _roundingMode_ to ? GetOption(_opts_, *"roundingMode"*, ~string~, « *"ceil"*, *"floor"*, *"expand"*, *"trunc"*, *"halfCeil"*, *"halfFloor"*, *"halfExpand"*, *"halfTrunc"*, *"halfEven"* », *"halfEven"*).
+            1. Set _significantDigits_ to ? GetOption(_opts_, *"significantDigits"*, ~number~, ~empty~, *undefined*).
+            1. Let _unit_ be ? GetOption(_opts_, *"unit"*, ~string~, ~empty~, *undefined*).
           1. If _fractionDigits_ is not *undefined*, then
             1. If _significantDigits_ is not *undefined*, throw a *RangeError* exception.
             1. If _fractionDigits_ is not an integral Number, throw a *RangeError* exception.


### PR DESCRIPTION
The unit will surely be the most common option passed to the `Amount` constructor and `.convertTo`. Units even have their own slot in the data model. Here, we amend the spec text for the `Amount` constructor and `.convertTo`, specifically, `GetAmountOptions` and `GetAmountConvertToOptions`, to extract an Amount's unit as either a given String (new) or as an `unit` option in an option bag (old).

Also, update the README to document the shorthand.

Closes #119