### PR TITLE
Reject units that contain whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Note: ⚠️  All property/method names up for bikeshedding.
 
 * `new Amount(value[, options])`. Constructs an Amount with the numerical value of `value`
   and optional `options`, of which the following are supported (all being optional):
-  * `unit` (String): A unit identifier associated with the numerical value, which must not be an empty string.
+  * `unit` (String): A unit identifier associated with the numerical value, which must not be an empty string and must not contain whitespace. Unit strings are never trimmed or otherwise normalized.
     As a shorthand, `options` may be given directly as a String, which is equivalent to passing `{ unit: options }`,
     so `new Amount(42, "meter")` is the same as `new Amount(42, { unit: "meter" })`.
   * `fractionDigits`: the number of fractional digits the mathematical value should have (can be less than, equal to, or greater than the actual number of fractional digits that the underlying mathematical value has when rendered as a decimal digit string)

--- a/spec.emu
+++ b/spec.emu
@@ -81,44 +81,7 @@ location: https://tc39.es/proposal-amount/
         </h1>
         <dl class="header">
           <dt>description</dt>
-          <dd>It validates the given _opts_ for creating an Amount and returns a Record with slots set to appropriate marthematical values (or *undefined*). A String _opts_ is treated as a convenient shorthand for specifying a unit.</dd>
-        </dl>
-        <emu-alg>
-          1. Let _fractionDigits_ be *undefined*.
-          1. Let _significantDigits_ be *undefined*.
-          1. Let _roundingMode_ be *"halfEven"*.
-          1. If _opts_ is a String, then
-            1. Let _unit_ be _opts_.
-          1. Else,
-            1. Set _opts_ to ? GetOptionsObject(_opts_).
-            1. Set _fractionDigits_ to ? GetOption(_opts_, *"fractionDigits"*, ~number~, ~empty~, *undefined*).
-            1. Set _roundingMode_ to ? GetOption(_opts_, *"roundingMode"*, ~string~, « *"ceil"*, *"floor"*, *"expand"*, *"trunc"*, *"halfCeil"*, *"halfFloor"*, *"halfExpand"*, *"halfTrunc"*, *"halfEven"* », *"halfEven"*).
-            1. Set _significantDigits_ to ? GetOption(_opts_, *"significantDigits"*, ~number~, ~empty~, *undefined*).
-            1. Let _unit_ be ? GetOption(_opts_, *"unit"*, ~string~, ~empty~, *undefined*).
-          1. If _fractionDigits_ is not *undefined*, then
-            1. If _significantDigits_ is not *undefined*, throw a *RangeError* exception.
-            1. If _fractionDigits_ is not an integral Number, throw a *RangeError* exception.
-            1. Set _fractionDigits_ to ℝ(_fractionDigits_).
-            1. If _fractionDigits_ is not in the inclusive interval from 0 to 100, throw a *RangeError* exception.
-          1. Else if _significantDigits_ is not *undefined*, then
-            1. If _significantDigits_ is not an integral Number, throw a *RangeError* exception.
-            1. Set _significantDigits_ to ℝ(_significantDigits_).
-            1. If _significantDigits_ is not in the inclusive interval from 1 to 21, throw a *RangeError* exception.
-          1. If _unit_ is not *undefined*, then
-            1. If _unit_ is the empty String, throw a *RangeError* exception.
-            1. If _unit_ contains any code point in the union of |WhiteSpace| and |LineTerminator|, throw a *RangeError* exception.
-          1. Return the Record { [[FractionDigits]]: _fractionDigits_, [[RoundingMode]]: _roundingMode_, [[SignificantDigits]]: _significantDigits_, [[Unit]]: _unit_ }.
-        </emu-alg>
-      </emu-clause>
-
-      <emu-clause id="sec-amount-getamountconverttooptions" type="abstract operation">
-        <h1>GetAmountConvertToOptions (
-          _opts_: an ECMAScript language value
-        ): either a normal completion containing a Record with fields [[FractionDigits]] (a non-negative integer or *undefined*), [[RoundingMode]] (a <emu-xref href="#dfn-amount-rounding-mode">rounding mode</emu-xref>), [[SignificantDigits]] (a positive integer or *undefined*), and [[Unit]] (a String or *undefined*) or a throw completion
-        </h1>
-        <dl class="header">
-          <dt>description</dt>
-          <dd>It validates the given _opts_ for converting an Amount to another Amount and returns a Record with slots set to appropriate marthematical values (or *undefined*). A String _opts_ is treated as convenient shorthand for specifying a unit.</dd>
+          <dd>It validates the given _opts_ for creating an Amount or converting an Amount to another Amount and returns a Record with slots set to appropriate mathematical values (or *undefined*). A String _opts_ is treated as a convenient shorthand for specifying a unit.</dd>
         </dl>
         <emu-alg>
           1. Let _fractionDigits_ be *undefined*.
@@ -455,7 +418,7 @@ location: https://tc39.es/proposal-amount/
       1. Perform ? RequireInternalSlot(_O_, [[AmountValue]]).
       1. Let _sourceUnit_ be _O_.[[Unit]].
       1. If _sourceUnit_ is *undefined*, throw a *TypeError* exception.
-      1. Let _validatedOpts_ be ? GetAmountConvertToOptions(_options_).
+      1. Let _validatedOpts_ be ? GetAmountOptions(_options_).
       1. Let _targetUnit_ be _validatedOpts_.[[Unit]].
       1. If _targetUnit_ is *undefined*, throw a *TypeError* exception.
       1. Let _roundingMode_ be _validatedOpts_.[[RoundingMode]].

--- a/spec.emu
+++ b/spec.emu
@@ -104,7 +104,9 @@ location: https://tc39.es/proposal-amount/
             1. If _significantDigits_ is not an integral Number, throw a *RangeError* exception.
             1. Set _significantDigits_ to ℝ(_significantDigits_).
             1. If _significantDigits_ is not in the inclusive interval from 1 to 21, throw a *RangeError* exception.
-          1. If _unit_ is the empty String, throw a *RangeError* exception.
+          1. If _unit_ is not *undefined*, then
+            1. If _unit_ is the empty String, throw a *RangeError* exception.
+            1. If _unit_ contains any code point in the union of |WhiteSpace| and |LineTerminator|, throw a *RangeError* exception.
           1. Return the Record { [[FractionDigits]]: _fractionDigits_, [[RoundingMode]]: _roundingMode_, [[SignificantDigits]]: _significantDigits_, [[Unit]]: _unit_ }.
         </emu-alg>
       </emu-clause>
@@ -139,7 +141,9 @@ location: https://tc39.es/proposal-amount/
             1. If _significantDigits_ is not an integral Number, throw a *RangeError* exception.
             1. Set _significantDigits_ to ℝ(_significantDigits_).
             1. If _significantDigits_ is not in the inclusive interval from 1 to 21, throw a *RangeError* exception.
-          1. If _unit_ is the empty String, throw a *RangeError* exception.
+          1. If _unit_ is not *undefined*, then
+            1. If _unit_ is the empty String, throw a *RangeError* exception.
+            1. If _unit_ contains any code point in the union of |WhiteSpace| and |LineTerminator|, throw a *RangeError* exception.
           1. Return the Record { [[FractionDigits]]: _fractionDigits_, [[RoundingMode]]: _roundingMode_, [[SignificantDigits]]: _significantDigits_, [[Unit]]: _unit_ }.
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
In #127, the consensus is to reject unit strings containing whitespace. Here, we modify `GetAmountOptions` to throw a `RangeError` if given unit string that contains any code point in the union of the `WhiteSpace` or `LineTerminator` productions (taking inspiration from the definition of white space used by `TrimString` in 262). This follows the precedent set by Temporal and Intl.Locale.

Update the README to match.

Remove the `GetAmountConvertToOptions` AO, which has become identical to `GetAmountOptions`.

Closes #127