### PR TITLE
Editorial: Tweak the editor's note for the Amount constructor

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -358,9 +358,7 @@ location: https://tc39.es/proposal-amount/
         <p>A String argument must denote a finite mathematical value. *"NaN"*, *"Infinity"*, *"+Infinity"*, *"-Infinity"*, and *""* are rejected, as are Strings with leading or trailing white space or other extraneous contents.</p>
       </emu-note>
       <emu-note type="editor">
-	<p>
-	  We intend to move 402's FormatNumericToString, and its dependent AOs, to 262, possibly renamed.
-	</p>
+        <p>We intend to move ECMA-402 FormatNumericToString and its dependent operations to ECMA-262, possibly renamed.</p>
       </emu-note>
     </emu-clause>
   </emu-clause>


### PR DESCRIPTION
Remove unnecessary commas and (per ECMA-262 convention) make it a single source line.